### PR TITLE
swap CAN bus library to better support newer ESPs

### DIFF
--- a/include/PylontechCanReceiver.h
+++ b/include/PylontechCanReceiver.h
@@ -3,8 +3,8 @@
 
 #include "Configuration.h"
 #include <espMqttClient.h>
+#include <driver/twai.h>
 #include <Arduino.h>
-#include <Hoymiles.h>
 #include <memory>
 
 #ifndef PYLONTECH_PIN_RX
@@ -24,15 +24,16 @@ public:
     void mqtt();
 
 private:
-    uint8_t readUnsignedInt8();
-    uint16_t readUnsignedInt16();
-    int16_t readSignedInt16();
+    uint16_t readUnsignedInt16(uint8_t *data);
+    int16_t readSignedInt16(uint8_t *data);
     void readString(char* str, uint8_t numBytes);
     void readBooleanBits8(bool* b, uint8_t numBits);
     float scaleValue(int16_t value, float factor);
     bool getBit(uint8_t value, uint8_t bit);
 
     uint32_t _lastPublish;
+    twai_general_config_t g_config;
+
 };
 
 extern PylontechCanReceiverClass PylontechCanReceiver;

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,6 @@ lib_deps =
     nrf24/RF24 @ ^1.4.5
     olikraus/U8g2 @ ^2.34.13
     buelowp/sunset @ ^1.1.7
-    https://github.com/berni2288/arduino-CAN
 
 extra_scripts =
     pre:auto_firmware_version.py


### PR DESCRIPTION
Hi,

I tried to get my Pylontech Battery to speak to the ESP today but was not successful.
The can library (CAN.h) that is used for this link has a number of pending pull requests that seem to be related to newer ESPs. I tried to use the lib with a different device in the past and had similar issues.
I switched to twai.h which is more up to date. Also expressif claims that there are some HW related fixes implemented in this lib. I was able to read the Pylontech battery values with this change.

@berni2288 I understand that you have committed this feature originally. Can you check and comment?

Also I replaced the Messages printout.

Thanks,
Malte 