### PR TITLE
Producing DC Channel aware power limit application

### DIFF
--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -226,13 +226,16 @@ void PowerLimiterClass::setNewPowerLimit(std::shared_ptr<InverterAbstract> inver
 
         std::list<ChannelNum_t> dcChnls = inverter->Statistics()->getChannelsByType(TYPE_DC);
         int dcProdChnls = 0, dcTotalChnls = dcChnls.size();
-        for (auto& c : dcChnls){
-            if (inverter->Statistics()->getChannelFieldValue(TYPE_DC, c, FLD_PDC) > 0)
+        for (auto& c : dcChnls) {
+            if (inverter->Statistics()->getChannelFieldValue(TYPE_DC, c, FLD_PDC) > 0) {
                 dcProdChnls++;
+            }
         }
         int32_t effPowerLimit = round(newPowerLimit * static_cast<float>(dcTotalChnls) / dcProdChnls);
-        if (effPowerLimit > config.PowerLimiter_UpperPowerLimit)
-            effPowerLimit = config.PowerLimiter_UpperPowerLimit;
+        uint16_t inverterMaxPower = inverter->DevInfo()->getMaxPower();
+        if (effPowerLimit > inverterMaxPower) {
+            effPowerLimit = inverterMaxPower;
+        }
 
         inverter->sendActivePowerControlRequest(Hoymiles.getRadio(), effPowerLimit, PowerLimitControlType::AbsolutNonPersistent);
         _lastRequestedPowerLimit = newPowerLimit;

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -230,7 +230,7 @@ void PowerLimiterClass::setNewPowerLimit(std::shared_ptr<InverterAbstract> inver
             if (inverter->Statistics()->getChannelFieldValue(TYPE_DC, c, FLD_PDC) > 0)
                 dcProdChnls++;
         }
-        int32_t effPowerLimit = round(newPowerLimit * (float)dcTotalChnls / dcProdChnls);
+        int32_t effPowerLimit = round(newPowerLimit * static_cast<float>(dcTotalChnls) / dcProdChnls);
         if (effPowerLimit > config.PowerLimiter_UpperPowerLimit)
             effPowerLimit = config.PowerLimiter_UpperPowerLimit;
 


### PR DESCRIPTION
Following the observations the inverter internally distributes any applied power limit across all DC channels.
In case not all DC channels are connected only a fraction of the requested power limit becomes effective when the power limiter kicks in.

The proposed modification improves that by taking the number of actually producing DC channels into account to artificially increase the applied power limit accordingly.