### PR TITLE
Mppt string for SmartSolar 150/48 is wrong

### DIFF
--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -391,7 +391,7 @@ String VeDirectFrameHandler::getPidAsString(uint16_t pid)
 			strPID =  "SmartSolar MPPT 100|50";
 			break;
 		case 0XA058:
-			strPID =  "SmartSolar MPPT 100|35";
+			strPID =  "SmartSolar MPPT 150|35";
 			break;
 		case 0XA059:
 			strPID =  "SmartSolar MPPT 150|10 rev2";


### PR DESCRIPTION
I have an SmartSolar MPPT 150/35which shows the wrong string in the UI. Fixed

![Screenshot 2023-04-06 195850](https://user-images.githubusercontent.com/88371275/231241543-862c4ffd-8d04-4f05-8ea0-35838e33560f.png)
