### PR TITLE
Changing Huawei SPI interface

### DIFF
--- a/src/Huawei_can.cpp
+++ b/src/Huawei_can.cpp
@@ -22,7 +22,7 @@ void HuaweiCanClass::init(uint8_t huawei_miso, uint8_t huawei_mosi, uint8_t huaw
         return;
     }
 
-    spi = new SPIClass(VSPI);
+    spi = new SPIClass(HSPI);
     spi->begin(huawei_clk, huawei_miso, huawei_mosi, huawei_cs);
     pinMode(huawei_cs, OUTPUT);
     digitalWrite(huawei_cs, HIGH);


### PR DESCRIPTION
This is a leftover from the discussion around the SPI interface change here:
https://github.com/helgeerbe/OpenDTU-OnBattery/pull/144

Back then I submitted a PR to change the SPI interface in openDTU that got rejected (for reasons that made sense) but I forgot to make the change to the Huawei related code.

The conflict is in https://github.com/helgeerbe/OpenDTU-OnBattery/blob/master/src/InverterSettings.cpp which also uses the VSPI interface (line 26)