### PR TITLE
Bring back the sun indicator

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -7,6 +7,11 @@
 #include <Hoymiles.h>
 #include <memory>
 
+#define PL_UI_STATE_INACTIVE 0
+#define PL_UI_STATE_CHARGING 1
+#define PL_UI_STATE_USE_SOLAR_ONLY 2
+#define PL_UI_STATE_USE_SOLAR_AND_BATTERY 3
+
 typedef enum {
     SHUTDOWN = 0, 
     ACTIVE
@@ -22,7 +27,7 @@ class PowerLimiterClass {
 public:
     void init();
     void loop();
-    plStates getPowerLimiterState();
+    uint8_t getPowerLimiterState();
     int32_t getLastRequestedPowewrLimit();
     void setDisable(bool disable);
     bool getDisable();

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -97,8 +97,27 @@ void PowerLimiterClass::loop()
     setNewPowerLimit(inverter, newPowerLimit);
 }
 
-plStates PowerLimiterClass::getPowerLimiterState() {
-    return _plState;
+uint8_t PowerLimiterClass::getPowerLimiterState() {
+    CONFIG_T& config = Configuration.get();
+
+    std::shared_ptr<InverterAbstract> inverter = Hoymiles.getInverterByPos(config.PowerLimiter_InverterId);
+    if (inverter == nullptr || !inverter->isReachable()) {
+        return PL_UI_STATE_INACTIVE;
+    }
+
+    if (inverter->isProducing() && _batteryDischargeEnabled) {
+      return PL_UI_STATE_USE_SOLAR_AND_BATTERY;
+    }
+
+    if (inverter->isProducing() && !_batteryDischargeEnabled) {
+      return PL_UI_STATE_USE_SOLAR_ONLY;
+    }
+
+    if(VeDirect.veFrame.PPV > 0) {
+      return PL_UI_STATE_CHARGING;
+    }
+
+    return PL_UI_STATE_INACTIVE;
 }
 
 int32_t PowerLimiterClass::getLastRequestedPowewrLimit() {


### PR DESCRIPTION
@helgeerbe mentioned here: https://github.com/helgeerbe/OpenDTU-OnBattery/pull/172#issuecomment-1523468992 that I broke the sun indicator for Power Limiter solar pass-through. I investigated and believe the code in this PR fixes this. It works for me but I hardly ever get direct SolarPassthrough in my setup. 
Can you kindly check?

Note: I did not compare the MPPT power and the inverter power to indicate if the battery is actually being discharged or charged. Is that the desired behavior or shall this be done?
Note 2: The UI shows the last requested inverter power currently. This is correct as per methods used currently but also means that there is a power value shown case if the inverter is off. Should this indicate 0 in this case?