### PR TITLE
DPL: fix efficiency calculation

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -56,7 +56,7 @@ private:
     bool canUseDirectSolarPower();
     int32_t calcPowerLimit(std::shared_ptr<InverterAbstract> inverter, bool solarPowerEnabled, bool batteryDischargeEnabled);
     void setNewPowerLimit(std::shared_ptr<InverterAbstract> inverter, int32_t newPowerLimit);
-    int32_t getDirectSolarPower();
+    int32_t getSolarChargePower();
     float getLoadCorrectedVoltage(std::shared_ptr<InverterAbstract> inverter);
     bool isStartThresholdReached(std::shared_ptr<InverterAbstract> inverter);
     bool isStopThresholdReached(std::shared_ptr<InverterAbstract> inverter);


### PR DESCRIPTION
there is no need to assume and hardcode a fixed efficiency for the Victron solar charger. the charger reports the voltage and current at its battery terminal, which can be used to calculate the charger's actual power output.

the fallback to 100% for the efficiency of the Hoymiles inverter, in case it is not producing power, is too optimistic. this commit proposes to use 96.7% as the efficiency for that case, which is the peak efficiency for many (all?) Hoymiles inverters as per datasheet. that value should be closer to the real efficiency that will be achieved once the inverter is turned on.