### PR TITLE
set default values for pin mappings if not provided

### DIFF
--- a/src/PinMapping.cpp
+++ b/src/PinMapping.cpp
@@ -62,6 +62,46 @@
 #define CMT_SDIO -1
 #endif
 
+#ifndef VICTRON_PIN_TX
+#define VICTRON_PIN_TX -1
+#endif
+
+#ifndef VICTRON_PIN_RX
+#define VICTRON_PIN_RX -1
+#endif
+
+#ifndef PYLONTECH_PIN_RX
+#define PYLONTECH_PIN_RX -1
+#endif
+
+#ifndef PYLONTECH_PIN_TX
+#define PYLONTECH_PIN_TX -1
+#endif
+
+#ifndef HUAWEI_PIN_MISO
+#define HUAWEI_PIN_MISO -1
+#endif
+
+#ifndef HUAWEI_PIN_MOSI
+#define HUAWEI_PIN_MOSI -1
+#endif
+
+#ifndef HUAWEI_PIN_SCLK
+#define HUAWEI_PIN_SCLK -1
+#endif
+
+#ifndef HUAWEI_PIN_CS
+#define HUAWEI_PIN_CS -1
+#endif
+
+#ifndef HUAWEI_PIN_IRQ
+#define HUAWEI_PIN_IRQ -1
+#endif
+
+#ifndef HUAWEI_PIN_POWER
+#define HUAWEI_PIN_POWER -1
+#endif
+
 PinMappingClass PinMapping;
 
 PinMappingClass::PinMappingClass()


### PR DESCRIPTION
in the spirit of e8fee49dc838a0ebe860b520c4700a19b04886d6 in the upstream project tbnobody/OpenDTU, this change provides default values for pin mappings if the pin mappings were not provided through the platformio environment.