### PR TITLE
DPL: use vedirect isdatavalid

### DIFF
--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -216,7 +216,8 @@ bool PowerLimiterClass::canUseDirectSolarPower()
     CONFIG_T& config = Configuration.get();
 
     if (!config.PowerLimiter_SolarPassThroughEnabled
-            || !config.Vedirect_Enabled) {
+            || !config.Vedirect_Enabled
+            || !VeDirect.isDataValid()) {
         return false;
     }
 

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -221,12 +221,7 @@ bool PowerLimiterClass::canUseDirectSolarPower()
         return false;
     }
 
-    if (VeDirect.veFrame.PPV < 20) {
-        // Not enough power
-        return false;
-    }
-
-    return true;
+    return VeDirect.veFrame.PPV >= 20; // enough power?
 }
 
 


### PR DESCRIPTION
in case the communication to the Victron charger is disrupted, the respective values in `VeDirect.veFrame` are not invalidated such that we would notice a problem. instead, `isDataValid()` should be used to make sure that the Victron charger is actually alive and that we can trust to use the reported values.