### PR TITLE
DPL: fix the configured upper limit not being respected

### DIFF
--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -340,7 +340,6 @@ void PowerLimiterClass::setNewPowerLimit(std::shared_ptr<InverterAbstract> inver
     // enforce configured upper power limit
     int32_t effPowerLimit = std::min(newPowerLimit, config.PowerLimiter_UpperPowerLimit);
 
-
     // scale the power limit by the amount of all inverter channels devided by
     // the amount of producing inverter channels. the inverters limit each of
     // the n channels to 1/n of the total power limit. scaling the power limit
@@ -355,7 +354,7 @@ void PowerLimiterClass::setNewPowerLimit(std::shared_ptr<InverterAbstract> inver
     if (dcProdChnls > 0) {
         MessageOutput.printf("[PowerLimiterClass::setNewPowerLimit] %d channels total, %d producing channels, scaling power limit\r\n",
                 dcTotalChnls, dcProdChnls);
-        effPowerLimit = round(newPowerLimit * static_cast<float>(dcTotalChnls) / dcProdChnls);
+        effPowerLimit = round(effPowerLimit * static_cast<float>(dcTotalChnls) / dcProdChnls);
         if (effPowerLimit > inverter->DevInfo()->getMaxPower()) {
             effPowerLimit = inverter->DevInfo()->getMaxPower();
         }
@@ -364,8 +363,9 @@ void PowerLimiterClass::setNewPowerLimit(std::shared_ptr<InverterAbstract> inver
     // Check if the new value is within the limits of the hysteresis
     auto diff = std::abs(effPowerLimit - _lastRequestedPowerLimit);
     if ( diff < config.PowerLimiter_TargetPowerConsumptionHysteresis) {
-        MessageOutput.printf("[PowerLimiterClass::setNewPowerLimit] reusing old limit: %d W, diff: %d, hysteresis: %d\r\n",
-                _lastRequestedPowerLimit, diff, config.PowerLimiter_TargetPowerConsumptionHysteresis);
+        MessageOutput.printf("[PowerLimiterClass::setNewPowerLimit] reusing old limit: %d W, diff: %d, hysteresis: %d, requested power limit: %d\r\n",
+                _lastRequestedPowerLimit, diff,
+                config.PowerLimiter_TargetPowerConsumptionHysteresis, newPowerLimit);
         return;
     }
 


### PR DESCRIPTION
the requested `newPowerLimit` was indeed limited to the configured maximum inverter output and the result was stored in `effPowerLimit`. later, however, `effPowerLimit` must be scaled up (if necessary), not `newPowerLimit`. the latter variable is not respecting the configured maximum inverter output.

Closes #284.