### PR TITLE
DPL: add status, improve responsiveness

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -32,6 +32,7 @@ public:
         PowerMeterTimeout,
         PowerMeterPending,
         InverterInvalid,
+        InverterChanged,
         InverterOffline,
         InverterCommandsDisabled,
         InverterLimitPending,
@@ -62,6 +63,7 @@ private:
     Status _lastStatus = Status::Initializing;
     uint32_t _lastStatusPrinted = 0;
     uint8_t _mode = PL_MODE_ENABLE_NORMAL_OP;
+    std::shared_ptr<InverterAbstract> _inverter = nullptr;
     bool _batteryDischargeEnabled = false;
     uint32_t _nextInverterRestart = 0; // Values: 0->not calculated / 1->no restart configured / >1->time of next inverter restart in millis()
     uint32_t _nextCalculateCheck = 5000; // time in millis for next NTP check to calulate restart

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -49,10 +49,6 @@ private:
     uint32_t _nextCalculateCheck = 5000; // time in millis for next NTP check to calulate restart
     bool _fullSolarPassThroughEnabled = false;
 
-    float _powerMeter1Power;
-    float _powerMeter2Power;
-    float _powerMeter3Power;
-
     bool canUseDirectSolarPower();
     int32_t calcPowerLimit(std::shared_ptr<InverterAbstract> inverter, bool solarPowerEnabled, bool batteryDischargeEnabled);
     void commitPowerLimit(std::shared_ptr<InverterAbstract> inverter, int32_t limit, bool enablePowerProduction);

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -41,6 +41,7 @@ public:
         UnconditionalSolarPassthrough,
         NoVeDirect,
         Settling,
+        Stable,
         LowerLimitUndercut
     };
 
@@ -57,6 +58,8 @@ private:
     bool _shutdownInProgress;
     Status _lastStatus = Status::Initializing;
     uint32_t _lastStatusPrinted = 0;
+    uint32_t _lastCalculation = 0;
+    uint32_t _calculationBackoffMs = 0;
     uint8_t _mode = PL_MODE_ENABLE_NORMAL_OP;
     std::shared_ptr<InverterAbstract> _inverter = nullptr;
     bool _batteryDischargeEnabled = false;
@@ -72,7 +75,7 @@ private:
     bool canUseDirectSolarPower();
     int32_t calcPowerLimit(std::shared_ptr<InverterAbstract> inverter, bool solarPowerEnabled, bool batteryDischargeEnabled);
     void commitPowerLimit(std::shared_ptr<InverterAbstract> inverter, int32_t limit, bool enablePowerProduction);
-    void setNewPowerLimit(std::shared_ptr<InverterAbstract> inverter, int32_t newPowerLimit);
+    bool setNewPowerLimit(std::shared_ptr<InverterAbstract> inverter, int32_t newPowerLimit);
     int32_t getSolarChargePower();
     float getLoadCorrectedVoltage(std::shared_ptr<InverterAbstract> inverter);
     bool isStartThresholdReached(std::shared_ptr<InverterAbstract> inverter);

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -38,6 +38,8 @@ public:
         InverterLimitPending,
         InverterPowerCmdPending,
         InverterStatsPending,
+        UnconditionalSolarPassthrough,
+        NoVeDirect,
         Settling,
         LowerLimitUndercut
     };
@@ -72,6 +74,8 @@ private:
     std::string const& getStatusText(Status status);
     void announceStatus(Status status);
     void shutdown(Status status);
+    int32_t inverterPowerDcToAc(std::shared_ptr<InverterAbstract> inverter, int32_t dcPower);
+    void unconditionalSolarPassthrough(std::shared_ptr<InverterAbstract> inverter);
     bool canUseDirectSolarPower();
     int32_t calcPowerLimit(std::shared_ptr<InverterAbstract> inverter, bool solarPowerEnabled, bool batteryDischargeEnabled);
     void commitPowerLimit(std::shared_ptr<InverterAbstract> inverter, int32_t limit, bool enablePowerProduction);

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -33,7 +33,7 @@ public:
     void init();
     void loop();
     uint8_t getPowerLimiterState();
-    int32_t getLastRequestedPowewrLimit();
+    int32_t getLastRequestedPowerLimit();
     void setMode(uint8_t mode);
     bool getMode();
     void calcNextInverterRestart();

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -53,15 +53,8 @@ public:
     void calcNextInverterRestart();
 
 private:
-    enum class plStates : unsigned {
-        INIT, // looping for the first time after system startup
-        ACTIVE, // normal operation, sending power limit updates to inverter
-        SHUTDOWN, // power limiter shuts down inverter
-        OFF // inverter was shut down, power limiter is NOT active
-    };
-
     int32_t _lastRequestedPowerLimit = 0;
-    plStates _plState = plStates::INIT;
+    bool _shutdownInProgress;
     Status _lastStatus = Status::Initializing;
     uint32_t _lastStatusPrinted = 0;
     uint8_t _mode = PL_MODE_ENABLE_NORMAL_OP;

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -33,6 +33,7 @@ public:
         PowerMeterPending,
         InverterInvalid,
         InverterOffline,
+        InverterCommandsDisabled,
         InverterLimitPending,
         InverterPowerCmdPending,
         InverterStatsPending,

--- a/lib/Hoymiles/src/inverters/HM_Abstract.cpp
+++ b/lib/Hoymiles/src/inverters/HM_Abstract.cpp
@@ -121,6 +121,10 @@ bool HM_Abstract::sendActivePowerControlRequest(float limit, PowerLimitControlTy
         return false;
     }
 
+    if (CMD_PENDING == SystemConfigPara()->getLastLimitCommandSuccess()) {
+        return false;
+    }
+
     if (type == PowerLimitControlType::RelativNonPersistent || type == PowerLimitControlType::RelativPersistent) {
         limit = min<float>(100, limit);
     }
@@ -144,6 +148,10 @@ bool HM_Abstract::resendActivePowerControlRequest()
 bool HM_Abstract::sendPowerControlRequest(bool turnOn)
 {
     if (!getEnableCommands()) {
+        return false;
+    }
+
+    if (CMD_PENDING == PowerCommand()->getLastPowerCommandSuccess()) {
         return false;
     }
 

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -34,6 +34,7 @@ std::string const& PowerLimiterClass::getStatusText(PowerLimiterClass::Status st
         { Status::PowerMeterPending, "waiting for sufficiently recent power meter reading" },
         { Status::InverterInvalid, "invalid inverter selection/configuration" },
         { Status::InverterOffline, "inverter is offline (polling enabled? radio okay?)" },
+        { Status::InverterCommandsDisabled, "inverter configuration prohibits sending commands" },
         { Status::InverterLimitPending, "waiting for a power limit command to complete" },
         { Status::InverterPowerCmdPending, "waiting for a start/stop/restart command to complete" },
         { Status::InverterStatsPending, "waiting for sufficiently recent inverter data" },
@@ -122,6 +123,11 @@ void PowerLimiterClass::loop()
     // data polling is disabled or the inverter is deemed offline
     if (!inverter->isReachable()) {
         return announceStatus(Status::InverterOffline);
+    }
+
+    // sending commands to the inverter is disabled
+    if (!_inverter->getEnableCommands()) {
+        return announceStatus(Status::InverterCommandsDisabled);
     }
 
     // concerns active power commands (power limits) only (also from web app or MQTT)

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -199,7 +199,7 @@ uint8_t PowerLimiterClass::getPowerLimiterState() {
     return PL_UI_STATE_INACTIVE;
 }
 
-int32_t PowerLimiterClass::getLastRequestedPowewrLimit() {
+int32_t PowerLimiterClass::getLastRequestedPowerLimit() {
     return _lastRequestedPowerLimit;
 }
 

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -58,6 +58,10 @@ void PowerLimiterClass::announceStatus(PowerLimiterClass::Status status)
     // otherwise repeat the info with a fixed interval.
     if (_lastStatus == status && millis() < _lastStatusPrinted + 10 * 1000) { return; }
 
+    // after announcing once that the DPL is disabled by configuration, it
+    // should just be silent while it is disabled.
+    if (status == Status::DisabledByConfig && _lastStatus == status) { return; }
+
     MessageOutput.printf("[%11.3f] DPL: %s\r\n",
         static_cast<double>(millis())/1000, getStatusText(status).c_str());
 

--- a/src/WebApi_ws_vedirect_live.cpp
+++ b/src/WebApi_ws_vedirect_live.cpp
@@ -145,7 +145,7 @@ void WebApiWsVedirectLiveClass::generateJsonResponse(JsonVariant& root)
     root["dpl"]["PLSTATE"] = -1;
     if (Configuration.get().PowerLimiter_Enabled)
         root["dpl"]["PLSTATE"] = PowerLimiter.getPowerLimiterState();
-    root["dpl"]["PLLIMIT"] = PowerLimiter.getLastRequestedPowewrLimit();
+    root["dpl"]["PLLIMIT"] = PowerLimiter.getLastRequestedPowerLimit();
 
     if (VeDirect.getLastUpdate() > _newestVedirectTimestamp) {
         _newestVedirectTimestamp = VeDirect.getLastUpdate();


### PR DESCRIPTION
This change focuses on two features: (1) The DPL loop is calculating a new power limit much more often, while not calculating anything while it is unreasonable to do so. (2) A DPL status is introduced, which shall make it more transparent to understand what the DPL is currently doing. The status is useful to be displayed on the web application in the future and is complementary to `getPowerLimiterState()`.

More conditions are checked before calculating a new power limit than before, e.g., `getEnableCommand()`, while the conditions that are checked should be much easiert to understand. Waiting for all radios to be idle was a very conservative condition, which is replaced by waiting for an empty command queue for the specific inverter. To implement this, a change is included that is also proposed in the upstream project at https://github.com/tbnobody/OpenDTU/pull/1093.

A copy of the `shared_ptr` to the target inverter is now kept within `PowerLimiterClass`, which enabled shutting the inverter down in case the configuration is changed. This is also a small step towards support for multiple inverters, where it makes sense to keep a container of inverters (or probably inverter wrapper classes).

The unconditional solar passthrough mode of operation (setup by MQTT) is now implemented in its own function, separate from the normal mode of operation. This should make sense as it is a distinct mode of operation. If the two are kept entangled, maintaining both modes might become a headache. A power meter reading is not required any more for this mode of operation.