### PR TITLE
DPL: check more requirements and fix backoff initialization

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -28,6 +28,7 @@ public:
         Initializing,
         DisabledByConfig,
         DisabledByMqtt,
+        WaitingForValidTimestamp,
         PowerMeterDisabled,
         PowerMeterTimeout,
         PowerMeterPending,

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -38,6 +38,7 @@ public:
         InverterCommandsDisabled,
         InverterLimitPending,
         InverterPowerCmdPending,
+        InverterDevInfoPending,
         InverterStatsPending,
         UnconditionalSolarPassthrough,
         NoVeDirect,

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -61,7 +61,8 @@ private:
     Status _lastStatus = Status::Initializing;
     uint32_t _lastStatusPrinted = 0;
     uint32_t _lastCalculation = 0;
-    uint32_t _calculationBackoffMs = 0;
+    static constexpr uint32_t _calculationBackoffMsDefault = 128;
+    uint32_t _calculationBackoffMs = _calculationBackoffMsDefault;
     uint8_t _mode = PL_MODE_ENABLE_NORMAL_OP;
     std::shared_ptr<InverterAbstract> _inverter = nullptr;
     bool _batteryDischargeEnabled = false;

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -292,7 +292,7 @@ void PowerLimiterClass::loop()
         return announceStatus(Status::Stable);
     }
 
-    _calculationBackoffMs = 128;
+    _calculationBackoffMs = _calculationBackoffMsDefault;
 }
 
 /**

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -40,6 +40,7 @@ std::string const& PowerLimiterClass::getStatusText(PowerLimiterClass::Status st
         { Status::InverterCommandsDisabled, "inverter configuration prohibits sending commands" },
         { Status::InverterLimitPending, "waiting for a power limit command to complete" },
         { Status::InverterPowerCmdPending, "waiting for a start/stop/restart command to complete" },
+        { Status::InverterDevInfoPending, "waiting for inverter device information to be available" },
         { Status::InverterStatsPending, "waiting for sufficiently recent inverter data" },
         { Status::UnconditionalSolarPassthrough, "unconditionally passing through all solar power (MQTT override)" },
         { Status::NoVeDirect, "VE.Direct disabled, connection broken, or data outdated" },
@@ -159,6 +160,13 @@ void PowerLimiterClass::loop()
     auto lastPowerCommandState = _inverter->PowerCommand()->getLastPowerCommandSuccess();
     if (CMD_PENDING == lastPowerCommandState) {
         return announceStatus(Status::InverterPowerCmdPending);
+    }
+
+    // a calculated power limit will always be limited to the reported
+    // device's max power. that upper limit is only known after the first
+    // DevInfoSimpleCommand succeeded.
+    if (_inverter->DevInfo()->getMaxPower() <= 0) {
+        return announceStatus(Status::InverterDevInfoPending);
     }
 
     if (PL_MODE_SOLAR_PT_ONLY == _mode) {


### PR DESCRIPTION
* wait for valid time information (as we know the Hoymiles library will do nothing until valid time information is available).
* wait for device info to be ready. otherwise we continuously calculcate the new power limit to be zero, until the `maxPower` info is available.
* fix the calculation backoff initialization: when initializing to zero, doubling will still make it zero, leading to useless high frequency power limit calculations after startup (until the inverter is ready and an actual non-zero power limit was calculated for the *second* time).