### PR TITLE
Disable PL debug mode, increasing power threshold for active channel

### DIFF
--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -495,18 +495,17 @@ bool PowerLimiterClass::setNewPowerLimit(std::shared_ptr<InverterAbstract> inver
     std::list<ChannelNum_t> dcChnls = inverter->Statistics()->getChannelsByType(TYPE_DC);
     int dcProdChnls = 0, dcTotalChnls = dcChnls.size();
     for (auto& c : dcChnls) {
-        if (inverter->Statistics()->getChannelFieldValue(TYPE_DC, c, FLD_PDC) > 1.0) {
+        if (inverter->Statistics()->getChannelFieldValue(TYPE_DC, c, FLD_PDC) > 2.0) {
             dcProdChnls++;
         }
     }
-    if (dcProdChnls > 0) {
+    if ((dcProdChnls > 0) && (dcProdChnls != dcTotalChnls)) {
         MessageOutput.printf("[PowerLimiterClass::setNewPowerLimit] %d channels total, %d producing channels, scaling power limit\r\n",
                 dcTotalChnls, dcProdChnls);
         effPowerLimit = round(effPowerLimit * static_cast<float>(dcTotalChnls) / dcProdChnls);
-        if (effPowerLimit > inverter->DevInfo()->getMaxPower()) {
-            effPowerLimit = inverter->DevInfo()->getMaxPower();
-        }
     }
+
+    effPowerLimit = std::min<int32_t>(effPowerLimit, inverter->DevInfo()->getMaxPower());
 
     // Check if the new value is within the limits of the hysteresis
     auto diff = std::abs(effPowerLimit - _lastRequestedPowerLimit);


### PR DESCRIPTION
Smaller PR that:

1. Disables debug printouts
2. Increases the threshold for producing channel detection.
3. Fixes an issue with maximum power limiting

Rationale:

1. The PL was recently changed to no longer run in a 10s interval. This causes the debug printouts to be printed way more often. I believe this has lead to stability issues highlighted here https://github.com/helgeerbe/OpenDTU-OnBattery/issues/298 
This PR disables the printouts for now which is kind of a hotfix

2. My Inverter reports a power of 0.9W on a single channel when idle. The other channels indicate about 1.5W. This triggers the producing channels detection code and will scale a requested limit by a factor of 1.3 when starting up. This PR increases the detection threshold to 2W.

3. When no active channels are detected the limit is not checked against the maximum inverter power. This PR makes this a mandatory check

**Issues / Questions**
Right now setNewPowerLimit enforces the maximum configured limit before the producing channel detection / scaling. This seems like a bug to me as the user would expect a UI configured value to be used.
Am I right here or is this intensional?

```
    // enforce configured upper power limit
    int32_t effPowerLimit = std::min(newPowerLimit, config.PowerLimiter_UpperPowerLimit);

    // scale the power limit by the amount of all inverter channels devided by
    // the amount of producing inverter channels. the inverters limit each of
    // the n channels to 1/n of the total power limit. scaling the power limit
    // ensures the total inverter output is what we are asking for.
    std::list<ChannelNum_t> dcChnls = inverter->Statistics()->getChannelsByType(TYPE_DC);
    int dcProdChnls = 0, dcTotalChnls = dcChnls.size();
    for (auto& c : dcChnls) {
        if (inverter->Statistics()->getChannelFieldValue(TYPE_DC, c, FLD_PDC) > 2.0) {
            dcProdChnls++;
        }
    }
    if (dcProdChnls > 0) {
        if (dcProdChnls != dcTotalChnls) {
          MessageOutput.printf("[PowerLimiterClass::setNewPowerLimit] %d channels total, %d producing channels, scaling power limit\r\n",
                  dcTotalChnls, dcProdChnls);
        }
        effPowerLimit = round(effPowerLimit * static_cast<float>(dcTotalChnls) / dcProdChnls);
    }
```