### PR TITLE
DPL: increase backoff while inverter is kept shut down

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -44,7 +44,6 @@ public:
         NoVeDirect,
         Settling,
         Stable,
-        LowerLimitUndercut
     };
 
     void init();
@@ -57,7 +56,7 @@ public:
 
 private:
     int32_t _lastRequestedPowerLimit = 0;
-    bool _shutdownInProgress;
+    uint32_t _shutdownTimeout = 0;
     Status _lastStatus = Status::Initializing;
     uint32_t _lastStatusPrinted = 0;
     uint32_t _lastCalculation = 0;
@@ -72,7 +71,8 @@ private:
 
     std::string const& getStatusText(Status status);
     void announceStatus(Status status);
-    void shutdown(Status status);
+    bool shutdown(Status status);
+    bool shutdown() { return shutdown(_lastStatus); }
     int32_t inverterPowerDcToAc(std::shared_ptr<InverterAbstract> inverter, int32_t dcPower);
     void unconditionalSolarPassthrough(std::shared_ptr<InverterAbstract> inverter);
     bool canUseDirectSolarPower();


### PR DESCRIPTION
if the new calculated power limit is below the minimum power limit setting, the inverter is shut down. the shutdown() function is called every time this condition is detected, which is also true if the inverter is kept shut down for longer. that happens while the battery is charging in particular (solar passthrough off). there are other cases.

in such cases we still want to get into the DPL status "stable". to be able to determine this stable state, we must know if the call to shutdown did actually initiate a shutdown or if the inverter is already shut down.

we then can forward this "changed" or "not changed" info up the call chain, where the loop() will know that the system is actually stable.

see discussion with @peff74 in #309 