### PR TITLE
Feature: set Huawei offline parameters via MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ Topics for 3 phases of a power meter is configurable. Given is an example for th
 | --------------------------------------- | ----- | ---------------------------------------------------- | -------------------------- |
 | huawei/cmd/limit_online_voltage         | W     | Online voltage (i.e. CAN bus connected)              | Volt (V)                   |
 | huawei/cmd/limit_online_current         | W     | Online current (i.e. CAN bus connected)              | Ampere (A)                 |
+| huawei/cmd/limit_offline_voltage        | W     | Offline voltage (i.e. CAN bus connected)             | Volt (V)                   |
+| huawei/cmd/limit_offline_current        | W     | Offline current (i.e. CAN bus connected)             | Ampere (A)                 |
 | huawei/cmd/power                        | W     | Controls output pin GPIO to drive solid state relais | 0 / 1                      |
 | huawei/data_age                         | R     | How old the data is                                  | Seconds                    |
 | huawei/input_voltage                    | R     | Input voltage                                        | Volt (V)                   |

--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ Topics for 3 phases of a power meter is configurable. Given is an example for th
 | --------------------------------------- | ----- | ---------------------------------------------------- | -------------------------- |
 | huawei/cmd/limit_online_voltage         | W     | Online voltage (i.e. CAN bus connected)              | Volt (V)                   |
 | huawei/cmd/limit_online_current         | W     | Online current (i.e. CAN bus connected)              | Ampere (A)                 |
-| huawei/cmd/limit_offline_voltage        | W     | Offline voltage (i.e. CAN bus connected)             | Volt (V)                   |
-| huawei/cmd/limit_offline_current        | W     | Offline current (i.e. CAN bus connected)             | Ampere (A)                 |
+| huawei/cmd/limit_offline_voltage        | W     | Offline voltage (i.e. CAN bus not connected)         | Volt (V)                   |
+| huawei/cmd/limit_offline_current        | W     | Offline current (i.e. CAN bus not connected)         | Ampere (A)                 |
 | huawei/cmd/power                        | W     | Controls output pin GPIO to drive solid state relais | 0 / 1                      |
 | huawei/data_age                         | R     | How old the data is                                  | Seconds                    |
 | huawei/input_voltage                    | R     | Input voltage                                        | Volt (V)                   |

--- a/docs/MQTT_Topics.md
+++ b/docs/MQTT_Topics.md
@@ -158,6 +158,8 @@ cmd topics are used to set values. Status topics are updated from values set in 
 | --------------------------------------- | ----- | ---------------------------------------------------- | -------------------------- |
 | huawei/cmd/limit_online_voltage         | W     | Online voltage (i.e. CAN bus connected)              | Volt (V)                   |
 | huawei/cmd/limit_online_current         | W     | Online current (i.e. CAN bus connected)              | Ampere (A)                 |
+| huawei/cmd/limit_offline_voltage        | W     | Offline voltage (i.e. CAN bus connected)             | Volt (V)                   |
+| huawei/cmd/limit_offline_current        | W     | Offline current (i.e. CAN bus connected)             | Ampere (A)                 |
 | huawei/cmd/mode                         | W     | Controls GPIO output pin to switch slot detect       | 0 (off) / 1 (on) / 2 (set automatically depending on online_current value) / 3 (set automatically based on Power Meter reading ) |
 | huawei/data_age                         | R     | How old the data is                                  | Seconds                    |
 | huawei/input_voltage                    | R     | Input voltage                                        | Volt (V)                   |

--- a/docs/MQTT_Topics.md
+++ b/docs/MQTT_Topics.md
@@ -158,8 +158,8 @@ cmd topics are used to set values. Status topics are updated from values set in 
 | --------------------------------------- | ----- | ---------------------------------------------------- | -------------------------- |
 | huawei/cmd/limit_online_voltage         | W     | Online voltage (i.e. CAN bus connected)              | Volt (V)                   |
 | huawei/cmd/limit_online_current         | W     | Online current (i.e. CAN bus connected)              | Ampere (A)                 |
-| huawei/cmd/limit_offline_voltage        | W     | Offline voltage (i.e. CAN bus connected)             | Volt (V)                   |
-| huawei/cmd/limit_offline_current        | W     | Offline current (i.e. CAN bus connected)             | Ampere (A)                 |
+| huawei/cmd/limit_offline_voltage        | W     | Offline voltage (i.e. CAN bus not connected)         | Volt (V)                   |
+| huawei/cmd/limit_offline_current        | W     | Offline current (i.e. CAN bus not connected)         | Ampere (A)                 |
 | huawei/cmd/mode                         | W     | Controls GPIO output pin to switch slot detect       | 0 (off) / 1 (on) / 2 (set automatically depending on online_current value) / 3 (set automatically based on Power Meter reading ) |
 | huawei/data_age                         | R     | How old the data is                                  | Seconds                    |
 | huawei/input_voltage                    | R     | Input voltage                                        | Volt (V)                   |

--- a/src/MqttHandleHuawei.cpp
+++ b/src/MqttHandleHuawei.cpp
@@ -12,6 +12,8 @@
 
 #define TOPIC_SUB_LIMIT_ONLINE_VOLTAGE "limit_online_voltage"
 #define TOPIC_SUB_LIMIT_ONLINE_CURRENT "limit_online_current"
+#define TOPIC_SUB_LIMIT_OFFLINE_VOLTAGE "limit_offline_voltage"
+#define TOPIC_SUB_LIMIT_OFFLINE_CURRENT "limit_offline_current"
 #define TOPIC_SUB_MODE "mode"
 
 MqttHandleHuaweiClass MqttHandleHuawei;
@@ -28,6 +30,8 @@ void MqttHandleHuaweiClass::init()
     String topic = MqttSettings.getPrefix();
     MqttSettings.subscribe(String(topic + "huawei/cmd/" + TOPIC_SUB_LIMIT_ONLINE_VOLTAGE).c_str(), 0, std::bind(&MqttHandleHuaweiClass::onMqttMessage, this, _1, _2, _3, _4, _5, _6));
     MqttSettings.subscribe(String(topic + "huawei/cmd/" + TOPIC_SUB_LIMIT_ONLINE_CURRENT).c_str(), 0, std::bind(&MqttHandleHuaweiClass::onMqttMessage, this, _1, _2, _3, _4, _5, _6));
+    MqttSettings.subscribe(String(topic + "huawei/cmd/" + TOPIC_SUB_LIMIT_OFFLINE_VOLTAGE).c_str(), 0, std::bind(&MqttHandleHuaweiClass::onMqttMessage, this, _1, _2, _3, _4, _5, _6));
+    MqttSettings.subscribe(String(topic + "huawei/cmd/" + TOPIC_SUB_LIMIT_OFFLINE_CURRENT).c_str(), 0, std::bind(&MqttHandleHuaweiClass::onMqttMessage, this, _1, _2, _3, _4, _5, _6));
     MqttSettings.subscribe(String(topic + "huawei/cmd/" + TOPIC_SUB_MODE).c_str(), 0, std::bind(&MqttHandleHuaweiClass::onMqttMessage, this, _1, _2, _3, _4, _5, _6));
 
     _lastPublish = millis();
@@ -104,24 +108,38 @@ void MqttHandleHuaweiClass::onMqttMessage(const espMqttClientTypes::MessagePrope
         MessageOutput.printf("Limit Voltage: %f V\r\n", payload_val);
         HuaweiCan.setValue(payload_val, HUAWEI_ONLINE_VOLTAGE);
 
+    } else if (!strcmp(setting, TOPIC_SUB_LIMIT_OFFLINE_VOLTAGE)) {
+        // Set current limit
+        MessageOutput.printf("Offline Limit Voltage: %f V\r\n", payload_val);
+        HuaweiCan.setValue(payload_val, HUAWEI_OFFLINE_VOLTAGE);
+
     } else if (!strcmp(setting, TOPIC_SUB_LIMIT_ONLINE_CURRENT)) {
         // Set current limit
         MessageOutput.printf("Limit Current: %f A\r\n", payload_val);
         HuaweiCan.setValue(payload_val, HUAWEI_ONLINE_CURRENT);
+
+    } else if (!strcmp(setting, TOPIC_SUB_LIMIT_OFFLINE_CURRENT)) {
+        // Set current limit
+        MessageOutput.printf("Offline Limit Current: %f A\r\n", payload_val);
+        HuaweiCan.setValue(payload_val, HUAWEI_OFFLINE_CURRENT);
+
     } else if (!strcmp(setting, TOPIC_SUB_MODE)) {
         // Control power on/off
         if(payload_val == 3) {
           MessageOutput.println("[Huawei MQTT::] Received MQTT msg. New mode: Full internal control");
           HuaweiCan.setMode(HUAWEI_MODE_AUTO_INT);
-        } 
+        }
+
         if(payload_val == 2) {
           MessageOutput.println("[Huawei MQTT::] Received MQTT msg. New mode: Internal on/off control, external power limit");
           HuaweiCan.setMode(HUAWEI_MODE_AUTO_EXT);
-        } 
+        }
+
         if(payload_val == 1) {
           MessageOutput.println("[Huawei MQTT::] Received MQTT msg. New mode: Turned ON");
           HuaweiCan.setMode(HUAWEI_MODE_ON);
-        }         
+        }
+                 
         if(payload_val == 0) {
           MessageOutput.println("[Huawei MQTT::] Received MQTT msg. New mode: Turned OFF");
           HuaweiCan.setMode(HUAWEI_MODE_OFF);


### PR DESCRIPTION
I have added the possibility to set the offline parameters for the Huawei power supply over MQTT.
The offline parameters are used if the power supply does not have a CAN connection at startup.
