### PR TITLE
Fix: WebApp Live-View: adjust window-title and header

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -6,7 +6,7 @@
     <link rel="shortcut icon" type="image/png" href="/favicon.png">
     <link rel="apple-touch-icon" href="/favicon.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OpenDTU</title>
+    <title>OpenDTU-onBattery</title>
   </head>
   <body>
     <noscript>

--- a/webapp/src/components/NavBar.vue
+++ b/webapp/src/components/NavBar.vue
@@ -11,9 +11,9 @@
                 <span v-else class="text-warning">
                     <BIconSun width="30" height="30" class="d-inline-block align-text-top" />
                 </span>
-                 OpenDTU
-                 <span class="text-info">
-                    <BIconBatteryCharging width="20" height="20" class="d-inline-block align-text-top" />
+                OpenDTU-onBattery
+                <span class="text-info">
+                    <BIconBatteryCharging width="20" height="20" class="d-inline-block align-text-center" />
                 </span>
             </router-link>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavAltMarkup"


### PR DESCRIPTION
adjust window-title and live-view header from OpenDTU to OpenDTU-onBattery 
Additionally change orientation of battery symbol to vertically centered (looks nicer)

![grafik](https://github.com/helgeerbe/OpenDTU-OnBattery/assets/4208120/2d5578aa-73d2-4550-a461-404d77f19e83)


Needs rebuild of Webapp!