### PR TITLE
PowerMeter fixes

### DIFF
--- a/include/PowerMeter.h
+++ b/include/PowerMeter.h
@@ -4,7 +4,7 @@
 #include "Configuration.h"
 #include <espMqttClient.h>
 #include <Arduino.h>
-#include <vector>
+#include <map>
 #include <list>
 #include "SDM.h"
 #include "sml.h"
@@ -59,7 +59,7 @@ private:
     float _powerMeterImport = 0.0;
     float _powerMeterExport = 0.0;
 
-    std::vector<String> _mqttSubscriptions;
+    std::map<String, float*> _mqttSubscriptions;
 
     void readPowerMeter();
 

--- a/include/PowerMeter.h
+++ b/include/PowerMeter.h
@@ -37,15 +37,17 @@ public:
         SOURCE_SML = 4
     };
     void init();
-    void mqtt();
     void loop();
-    void onMqttMessage(const espMqttClientTypes::MessageProperties& properties, const char* topic, const uint8_t* payload, size_t len, size_t index, size_t total);
     float getPowerTotal(bool forceUpdate = true);
     uint32_t getLastPowerMeterUpdate();
 
 private:
+    void mqtt();
+
+    void onMqttMessage(const espMqttClientTypes::MessageProperties& properties,
+        const char* topic, const uint8_t* payload, size_t len, size_t index, size_t total);
+
     bool _verboseLogging = true;
-    uint32_t _interval;
     uint32_t _lastPowerMeterCheck;
     // Used in Power limiter for safety check
     uint32_t _lastPowerMeterUpdate;

--- a/include/PowerMeter.h
+++ b/include/PowerMeter.h
@@ -4,8 +4,8 @@
 #include "Configuration.h"
 #include <espMqttClient.h>
 #include <Arduino.h>
-#include <Hoymiles.h>
-#include <memory>
+#include <vector>
+#include <list>
 #include "SDM.h"
 #include "sml.h"
 
@@ -59,7 +59,7 @@ private:
     float _powerMeterImport = 0.0;
     float _powerMeterExport = 0.0;
 
-    bool mqttInitDone = false;
+    std::vector<String> _mqttSubscriptions;
 
     void readPowerMeter();
 


### PR DESCRIPTION
When subscribing to a topic whose payload cannot be parsed as a float value, an exception would be triggered in the PowerMeter implementation. The code in this PR catches the exception and handles it gracefully:

```
Received MQTT message on topic: solar-staging/dtu/status
PowerMeterClass: cannot parse payload of topic 'solar-staging/dtu/status' as float: online
```

Make sure that the timestamp `_lastPowerMeterUpdate` is only updated by the MQTT callback if a topic was processed that actually matches one of the subscribed topics.

Upon changing the MQTT settings and submitting the new settings through the web application, PowerMeter::init() is called. That probably makes sense so it can be ensured that the topics are subscribed to using a possible new broker. However, the old subscriptions were not cancelled, resulting in the callback being called `n+1` times after `n` changes to the MQTT settings.

```
Received MQTT message on topic: grid/power/phase1/watts
PowerMeterClass: Updated from 'grid/power/phase1/watts', TotalPower: -10.00
PowerMeterClass: Updated from 'grid/power/phase1/watts', TotalPower: -10.00
PowerMeterClass: Updated from 'grid/power/phase1/watts', TotalPower: -10.00
Received MQTT message on topic: grid/power/phase2/watts
PowerMeterClass: Updated from 'grid/power/phase2/watts', TotalPower: -10.00
PowerMeterClass: Updated from 'grid/power/phase2/watts', TotalPower: -10.00
PowerMeterClass: Updated from 'grid/power/phase2/watts', TotalPower: -10.00
```

This problem is resolved by unsubscribing from all subscribed topics, if any, before resubscribing.

The subscriptions are organized in a std::map, which allows iterating them, which in turn allows for slightly more elegant code and less code overall.

Removed an unused member variable and moved private function to the private section of the class declaration.

Use a switch-case-statement over an if-else construct in `init()`.