### PR TITLE
execute MQTT client synchronously in main loop()

### DIFF
--- a/include/MqttSettings.h
+++ b/include/MqttSettings.h
@@ -10,6 +10,7 @@ class MqttSettingsClass {
 public:
     MqttSettingsClass();
     void init();
+    void loop();
     void performReconnect();
     bool getConnected();
     void publish(const String& subtopic, const String& payload);

--- a/src/MqttSettings.cpp
+++ b/src/MqttSettings.cpp
@@ -182,15 +182,21 @@ void MqttSettingsClass::init()
     createMqttClientObject();
 }
 
+void MqttSettingsClass::loop()
+{
+    if (nullptr == mqttClient) { return; }
+    mqttClient->loop();
+}
+
 void MqttSettingsClass::createMqttClientObject()
 {
     if (mqttClient != nullptr)
         delete mqttClient;
     const CONFIG_T& config = Configuration.get();
     if (config.Mqtt_Tls) {
-        mqttClient = static_cast<MqttClient*>(new espMqttClientSecure);
+        mqttClient = new espMqttClientSecure(espMqttClientTypes::UseInternalTask::NO);
     } else {
-        mqttClient = static_cast<MqttClient*>(new espMqttClient);
+        mqttClient = new espMqttClient(espMqttClientTypes::UseInternalTask::NO);
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -215,6 +215,8 @@ void loop()
 		VeDirect.loop();
         yield();
 	}
+    MqttSettings.loop();
+    yield();
     MqttHandleDtu.loop();
     yield();
     MqttHandleInverter.loop();


### PR DESCRIPTION
processing a published valued on a subscribed topic is currently running in a task that is not the task executing the main loop(). that's because the espMqttClient(Secure) was constructed without arguments, which selects the constructor with two arguments priority and core, both of which have default values. that constructor selects espMqttClientTypes::UseInternalTask::YES, causing a task to be created in which context the MQTT client loop is executed.

MQTT subscribers assume they are running in the same context as the main loop(). most code assumes exactly that. as the scheduler is preemptive and very little (none at all?) code is interlocked, we have to make sure to meet the programmer's expectations.

this changeset calls the MQTT client loop in the context of the main loop() and enforces the use of espMqttClientTypes::UseInternalTask::NO.

This aims to solve @the-lonely-one's problem described in #268 and a merge request against the upstream project will be created if this solves the problem.