### PR TITLE
Inhibit solar passthrough while battery below stop threshold

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -6,6 +6,7 @@
 #include <Arduino.h>
 #include <Hoymiles.h>
 #include <memory>
+#include <functional>
 
 #define PL_UI_STATE_INACTIVE 0
 #define PL_UI_STATE_CHARGING 1
@@ -82,8 +83,11 @@ private:
     bool setNewPowerLimit(std::shared_ptr<InverterAbstract> inverter, int32_t newPowerLimit);
     int32_t getSolarChargePower();
     float getLoadCorrectedVoltage();
+    bool testThreshold(float socThreshold, float voltThreshold,
+            std::function<bool(float, float)> compare);
     bool isStartThresholdReached();
     bool isStopThresholdReached();
+    bool isBelowStopThreshold();
     bool useFullSolarPassthrough(std::shared_ptr<InverterAbstract> inverter);
 };
 

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -81,9 +81,9 @@ private:
     void commitPowerLimit(std::shared_ptr<InverterAbstract> inverter, int32_t limit, bool enablePowerProduction);
     bool setNewPowerLimit(std::shared_ptr<InverterAbstract> inverter, int32_t newPowerLimit);
     int32_t getSolarChargePower();
-    float getLoadCorrectedVoltage(std::shared_ptr<InverterAbstract> inverter);
-    bool isStartThresholdReached(std::shared_ptr<InverterAbstract> inverter);
-    bool isStopThresholdReached(std::shared_ptr<InverterAbstract> inverter);
+    float getLoadCorrectedVoltage();
+    bool isStartThresholdReached();
+    bool isStopThresholdReached();
     bool useFullSolarPassthrough(std::shared_ptr<InverterAbstract> inverter);
 };
 


### PR DESCRIPTION
This PR mangles two changes. The commits are separated. They do, however, build on one another.

1. "Improve" the DPL verbose logging. Please see the commit message for a list of changes. Some are purely cosmetic, some are arguably improvements.
2. Inhibit solar passthrough if the battery SoC or voltage is below the respective stop threshold.

Reasons for 2:
* If solar passthrough is active for a couple of hours or days and the battery is slightly discharged the whole time because the inverter is using a little too much power, maybe because the losses are bigger than anticipated, then this becomes a problem.
* The battery self-discharges over time, which might become an issue on prolonged periods with little sunshine.
* The inverter uses power at night. Very little, but this inevitable drains power and if solar passthrough prevents the battery from charging for a longer time, it depletes. The same is true for the BMS.

For those circumstances I propose this new piece of the DPL puzzle: Solar passthrough is inhibited while the battery is below the stop threshold.

A new method `isBelowStopThreshold` in introduced. However, the code in `isStopThresholdReached` and `isStartThresholdReached` was not copied another time. Instead, a new generic implementation is used by all three methods.