### PR TITLE
VE.Direct: websocket and status API response size

### DIFF
--- a/include/WebApi_ws_vedirect_live.h
+++ b/include/WebApi_ws_vedirect_live.h
@@ -23,4 +23,5 @@ private:
     uint32_t _lastVedirectUpdateCheck = 0;
     uint32_t _lastWsCleanup = 0;
     uint32_t _newestVedirectTimestamp = 0;
+    static constexpr uint16_t _responseSize = 1024 + 128;
 };

--- a/src/WebApi_ws_vedirect_live.cpp
+++ b/src/WebApi_ws_vedirect_live.cpp
@@ -61,7 +61,7 @@ void WebApiWsVedirectLiveClass::loop()
             String buffer;
             // free JsonDocument as soon as possible
             {
-                DynamicJsonDocument root(2048);
+                DynamicJsonDocument root(_responseSize);
                 JsonVariant var = root;
                 generateJsonResponse(var);
                 serializeJson(root, buffer);
@@ -173,7 +173,7 @@ void WebApiWsVedirectLiveClass::onLivedataStatus(AsyncWebServerRequest* request)
         return;
     }
     try {
-        AsyncJsonResponse* response = new AsyncJsonResponse(false, 1024U);
+        AsyncJsonResponse* response = new AsyncJsonResponse(false, _responseSize);
         JsonVariant root = response->getRoot();
 
         generateJsonResponse(root);


### PR DESCRIPTION
```
the size allocated for the HTTP request response was too little,
while the size for the buffer of the websocket output was increased already.

add a new member variable and use it in both context, such that
increasing the buffer size to accomodate more space (for the JSON
data in particular) will benefit both contexts in the future.
```

I am working on changes to the Battery live view to accommodate the JK BMS values (and making it very generic for future battery interfaces) and I am stumbling on a couple of annoying problems. This is one of them.

All of the web API implementations should be checked for different buffer sizes, like the one fixed here. Or even better, the same member variable should be introduced to all of them to avoid this kind of problem in the future. If anybody reads this and would like a small exercise, this is a great opportunity for a small but valuable contribution to the project :wink: