### PR TITLE
live view: remove disabled -OnBattery-specifc views from DOM

### DIFF
--- a/webapp/src/views/HomeView.vue
+++ b/webapp/src/views/HomeView.vue
@@ -114,13 +114,9 @@
                 </div>
             </div>
         </div>
-        <VedirectView v-show="liveData.vedirect.enabled" />
-        <div v-show="liveData.battery.enabled" >
-          <BatteryView/>
-        </div>
-        <div v-show="liveData.huawei.enabled" >
-          <HuaweiView/>
-        </div>
+        <VedirectView v-if="liveData.vedirect.enabled" />
+        <BatteryView v-if="liveData.battery.enabled" />
+        <HuaweiView v-if="liveData.huawei.enabled" />
     </BasePage>
    
     <div class="modal" id="eventView" tabindex="-1">


### PR DESCRIPTION
```
instead of hiding views, we can also avoid adding them to
the DOM. this has a couple of advantages:

* no HTTP request for data is sent and no websocket connection
  is established for disabled features.
* JavaScript that causes errors due to incomplete or incompatible
  data of features that are disabled anyways do not trigger the
  browser debugger.
```

I am working on changes to the Battery live view to accommodate the JK BMS values (and making it very generic for future battery interfaces) and I am stumbling on a couple of annoying problems. This is one of them.