### PR TITLE
vite config: also proxy vedirect- and batterylivedata

### DIFF
--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -67,6 +67,16 @@ export default defineConfig({
         ws: true,
         changeOrigin: true
       },
+      '^/vedirectlivedata': {
+        target: 'ws://' + proxy_target,
+        ws: true,
+        changeOrigin: true
+      },
+      '^/batterylivedata': {
+        target: 'ws://' + proxy_target,
+        ws: true,
+        changeOrigin: true
+      },
       '^/console': {
         target: 'ws://' + proxy_target,
         ws: true,


### PR DESCRIPTION
`/vedirectlivedata` originally was also proxied in the version of the vite config in this project, but that was wiped with the recent merge of the upstream master branch.

This change re-adds `/vedirectlivedata` to be proxied and adds `/batterlivedata` to be proxied as well, which is also specific to this project and not part of the upstream project.