### PR TITLE
Messages: thread-safety and dynamic memory

### DIFF
--- a/include/MessageOutput.h
+++ b/include/MessageOutput.h
@@ -28,6 +28,8 @@ private:
     AsyncWebSocket* _ws = nullptr;
 
     std::mutex _msgLock;
+
+    void serialWrite(message_t const& m);
 };
 
 extern MessageOutputClass MessageOutput;

--- a/include/MessageOutput.h
+++ b/include/MessageOutput.h
@@ -2,11 +2,12 @@
 #pragma once
 
 #include <AsyncWebSocket.h>
-#include <HardwareSerial.h>
-#include <Stream.h>
+#include <Print.h>
+#include <freertos/task.h>
 #include <mutex>
-
-#define BUFFER_SIZE 500
+#include <vector>
+#include <unordered_map>
+#include <queue>
 
 class MessageOutputClass : public Print {
 public:
@@ -16,11 +17,15 @@ public:
     void register_ws_output(AsyncWebSocket* output);
 
 private:
-    AsyncWebSocket* _ws = NULL;
-    char _buffer[BUFFER_SIZE];
-    uint16_t _buff_pos = 0;
-    uint32_t _lastSend = 0;
-    bool _forceSend = false;
+    using message_t = std::vector<uint8_t>;
+
+    // we keep a buffer for every task and only write complete lines to the
+    // serial output and then move them to be pushed through the websocket.
+    // this way we prevent mangling of messages from different contexts.
+    std::unordered_map<TaskHandle_t, message_t> _task_messages;
+    std::queue<message_t> _lines;
+
+    AsyncWebSocket* _ws = nullptr;
 
     std::mutex _msgLock;
 };

--- a/src/MessageOutput.cpp
+++ b/src/MessageOutput.cpp
@@ -14,6 +14,21 @@ void MessageOutputClass::register_ws_output(AsyncWebSocket* output)
     _ws = output;
 }
 
+void MessageOutputClass::serialWrite(MessageOutputClass::message_t const& m)
+{
+    // on ESP32-S3, Serial.flush() blocks until a serial console is attached.
+    // operator bool() of HWCDC returns false if the device is not attached to
+    // a USB host. in general it makes sense to skip writing entirely if the
+    // default serial port is not ready.
+    if (!Serial) { return; }
+
+    size_t written = 0;
+    while (written < m.size()) {
+        written += Serial.write(m.data() + written, m.size() - written);
+    }
+    Serial.flush();
+}
+
 size_t MessageOutputClass::write(uint8_t c)
 {
     std::lock_guard<std::mutex> lock(_msgLock);
@@ -25,7 +40,7 @@ size_t MessageOutputClass::write(uint8_t c)
     message.push_back(c);
 
     if (c == '\n') {
-        Serial.write(message.data(), message.size());
+        serialWrite(message);
         _lines.emplace(std::move(message));
         _task_messages.erase(iter);
     }
@@ -49,7 +64,7 @@ size_t MessageOutputClass::write(const uint8_t *buffer, size_t size)
         message.push_back(c);
 
         if (c == '\n') {
-            Serial.write(message.data(), message.size());
+            serialWrite(message);
             _lines.emplace(std::move(message));
             message.clear();
             message.reserve(size - idx - 1);


### PR DESCRIPTION
I am trying to convince tbnobody that my changes proposed in https://github.com/tbnobody/OpenDTU/pull/1212 are valuable and do not have a detrimental effect on the project. However, the pull request sits idle.

In the meantime, I am still concerned that the web console message can only be trusted to some extent, as they can still be interleaved in between tasks, and because messages are simply dropped if any component tries to print "too much" messages until the next time MessageOutput's `loop()` is called.

For that reason, I would like to propose these changes to this project.

I have these changes deployed on my production unit and have no issues whatsoever. Additionally, I sneaked the changes into pre-releases of my fork, and I heard nothing about any issues.