### PR TITLE
JK BMS: fix SoC last update timestamp

### DIFF
--- a/src/BatteryStats.cpp
+++ b/src/BatteryStats.cpp
@@ -180,12 +180,10 @@ void JkBmsBatteryStats::mqttPublish() const
 
 void JkBmsBatteryStats::updateFrom(JkBms::DataPointContainer const& dp)
 {
-    _dataPoints.updateFrom(dp);
-
     using Label = JkBms::DataPointLabel;
 
     _manufacturer = "JKBMS";
-    auto oProductId = _dataPoints.get<Label::ProductId>();
+    auto oProductId = dp.get<Label::ProductId>();
     if (oProductId.has_value()) {
         _manufacturer = oProductId->c_str();
         auto pos = oProductId->rfind("JK");
@@ -194,12 +192,14 @@ void JkBmsBatteryStats::updateFrom(JkBms::DataPointContainer const& dp)
         }
     }
 
-    auto oSoCValue = _dataPoints.get<Label::BatterySoCPercent>();
+    auto oSoCValue = dp.get<Label::BatterySoCPercent>();
     if (oSoCValue.has_value()) {
         _SoC = *oSoCValue;
-        auto oSoCDataPoint = _dataPoints.getDataPointFor<Label::BatterySoCPercent>();
+        auto oSoCDataPoint = dp.getDataPointFor<Label::BatterySoCPercent>();
         _lastUpdateSoC = oSoCDataPoint->getTimestamp();
     }
+
+    _dataPoints.updateFrom(dp);
 
     _lastUpdate = millis();
 }


### PR DESCRIPTION
I noticed just hours ago that my inverter was disabled even though my battery was at 27%. The logs told me that the DPL had shut down the inverter because the battery SoC age was in the neighborhood of 4k seconds. So the voltage at the inverter must have been used as a fallback, and that reached the stop threshold. It then dawned on me that I made another dumb mistake:

For the MQTT integration, `JkBms::DataPointContainer::updateFrom()` was changed such that the data points timestamp reflects the last change of the data point value. That timestamp was used to set the SoC last update timestamp. However, that timestamp must reflect the last time the SoC was successfully received from the JK BMS so we could make sure the value was up to date.

This went unnoticed for the two days I was testing because the battery was always at a voltage level that kept the DPL going...

@peff74 @iukbox @indie89 FYI