### PR TITLE
Allow for defining only rx pin for VE.direct

### DIFF
--- a/src/PinMapping.cpp
+++ b/src/PinMapping.cpp
@@ -307,8 +307,7 @@ bool PinMappingClass::isValidEthConfig()
 
 bool PinMappingClass::isValidVictronConfig()
 {
-    return _pinMapping.victron_rx >= 0
-        && _pinMapping.victron_tx >= 0;
+    return _pinMapping.victron_rx >= 0;
 }
 
 bool PinMappingClass::isValidHuaweiConfig()

--- a/src/VictronSmartShunt.cpp
+++ b/src/VictronSmartShunt.cpp
@@ -13,7 +13,7 @@ bool VictronSmartShunt::init(bool verboseLogging)
     MessageOutput.printf("[VictronSmartShunt] Interface rx = %d, tx = %d\r\n",
             pin.battery_rx, pin.battery_tx);
 
-    if (pin.battery_rx < 0 || pin.battery_tx < 0) {
+    if (pin.battery_rx < 0) {
         MessageOutput.println(F("[VictronSmartShunt] Invalid pin config"));
         return false;
     }


### PR DESCRIPTION
This PR removes the necessity for defining a GPIO Pin for tx for Victron devices. Currently sending commands is not done and thus only the rx pin is used for MPPT and SmartShunt devices.

I thought about removing the victron_tx part completely in the code, but I think it will make potential future support for sending commands to the victron devices easier, but the tx pin should not be mandatory at the moment.

I think, this would eliminate a lot of confusion, what do you think?