### PR TITLE
Fix: PowerMeter: update _lastPowerMeterUpdate for SOURCE_SML

### DIFF
--- a/src/PowerMeter.cpp
+++ b/src/PowerMeter.cpp
@@ -134,14 +134,17 @@ void PowerMeterClass::loop()
     CONFIG_T const& config = Configuration.get();
     _verboseLogging = config.PowerMeter_VerboseLogging;
 
-    if (config.PowerMeter_Enabled && config.PowerMeter_Source == SOURCE_SML) {
+    if (!config.PowerMeter_Enabled) { return; }
+
+    if (config.PowerMeter_Source == SOURCE_SML) {
         if (!smlReadLoop()) {
             return;
+        } else {
+            _lastPowerMeterUpdate = millis();
         }
     }
 
-    if (!config.PowerMeter_Enabled
-            || (millis() - _lastPowerMeterCheck) < (config.PowerMeter_Interval * 1000)) {
+    if ((millis() - _lastPowerMeterCheck) < (config.PowerMeter_Interval * 1000)) {
         return;
     }
 


### PR DESCRIPTION
as soon as a read operation from an SML device was successful, the power meter timestamp must be updated.

return early (in any case) if the power meter is not enabled, simplifying if-statements.

closes #498.