### PR TITLE
Fix Display Bug for Huawei AC Charger in web interface

### DIFF
--- a/src/WebApi_Huawei.cpp
+++ b/src/WebApi_Huawei.cpp
@@ -50,7 +50,7 @@ void WebApiHuaweiClass::getJsonData(JsonObject& root) {
     root[F("input_temp")]["u"] = "°C";
     root[F("output_temp")]["v"] = rp->output_temp;
     root[F("output_temp")]["u"] = "°C";
-    root[F("efficiency")]["v"] = rp->efficiency;
+    root[F("efficiency")]["v"] = rp->efficiency * 100;
     root[F("efficiency")]["u"] = "%";
 
 }

--- a/src/WebApi_ws_Huawei.cpp
+++ b/src/WebApi_ws_Huawei.cpp
@@ -96,7 +96,7 @@ void WebApiWsHuaweiLiveClass::generateJsonResponse(JsonVariant& root)
     root[F("input_temp")]["u"] = "°C";
     root[F("output_temp")]["v"] = rp->output_temp;
     root[F("output_temp")]["u"] = "°C";
-    root[F("efficiency")]["v"] = rp->efficiency;
+    root[F("efficiency")]["v"] = rp->efficiency * 100;
     root[F("efficiency")]["u"] = "%";
 
 }

--- a/webapp/src/components/HuaweiView.vue
+++ b/webapp/src/components/HuaweiView.vue
@@ -70,7 +70,7 @@
                         </tr>
                         <tr>
                           <th scope="row">{{ $t('huawei.efficiency') }}</th>
-                          <td style="text-align: right">{{ huaweiData.efficiency.v.toFixed(3) }}</td>
+                          <td style="text-align: right">{{ huaweiData.efficiency.v.toFixed(1) }}</td>
                           <td>{{ huaweiData.efficiency.u }}</td>
                         </tr>
                       </tbody>


### PR DESCRIPTION
This aims to fix #487. It has however to be tested by someone having a Huawei charger as I do not have one.

In essence: Internally the efficiency is stored as a float value between 0 and 1. For the webinterface it has to be converted to % and thus the value has to be multiplied by 100.