### PR TITLE
Add temperature sensor data to Victron SmartShunt

### DIFF
--- a/include/BatteryStats.h
+++ b/include/BatteryStats.h
@@ -111,6 +111,7 @@ class VictronSmartShuntStats : public BatteryStats {
         float _voltage; 
         float _current;
         float _temperature;
+        bool _tempPresent;
         uint8_t _chargeCycles;
         uint32_t _timeToGo;
         float _chargedEnergy;

--- a/lib/VeDirectFrameHandler/VeDirectShuntController.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectShuntController.cpp
@@ -23,6 +23,7 @@ void VeDirectShuntController::textRxEvent(char* name, char* value)
 
 	if (strcmp(name, "T") == 0) {
 		_tmpFrame.T = atoi(value);
+		_tmpFrame.tempPresent = true;
 	}
 	else if (strcmp(name, "P") == 0) {
 		_tmpFrame.P = atoi(value);

--- a/lib/VeDirectFrameHandler/VeDirectShuntController.h
+++ b/lib/VeDirectFrameHandler/VeDirectShuntController.h
@@ -11,6 +11,7 @@ public:
 
     struct veShuntStruct : veStruct {
         int32_t T;                      // Battery temperature
+        bool tempPresent = false;       // Battery temperature sensor is attached to the shunt
         int32_t P;                      // Instantaneous power
         int32_t CE;                     // Consumed Amp Hours
         int32_t SOC;                    // State-of-charge

--- a/src/BatteryStats.cpp
+++ b/src/BatteryStats.cpp
@@ -214,6 +214,8 @@ void VictronSmartShuntStats::updateFrom(VeDirectShuntController::veShuntStruct c
     _chargedEnergy = shuntData.H18 / 100;
     _dischargedEnergy = shuntData.H17 / 100;
     _manufacturer = "Victron " + _modelName;
+    _temperature = shuntData.T;
+    _tempPresent = shuntData.tempPresent;
     
     // shuntData.AR is a bitfield, so we need to check each bit individually
     _alarmLowVoltage = shuntData.AR & 1;
@@ -235,6 +237,9 @@ void VictronSmartShuntStats::getLiveViewData(JsonVariant& root) const {
     addLiveViewValue(root, "chargeCycles", _chargeCycles, "", 0);
     addLiveViewValue(root, "chargedEnergy", _chargedEnergy, "KWh", 1);
     addLiveViewValue(root, "dischargedEnergy", _dischargedEnergy, "KWh", 1);
+    if (_tempPresent) {
+        addLiveViewValue(root, "temperature", _temperature, "°C", 0);
+    }
     
     addLiveViewAlarm(root, "lowVoltage", _alarmLowVoltage);
     addLiveViewAlarm(root, "highVoltage", _alarmHighVoltage);


### PR DESCRIPTION
If have bought and attached a battery temperature sensor to my SmartShunt. When the sensor is correctly set up via the Victron App, the SmartShunt also periodically sends temperature data. This PR adds the temperature to the web interface, when temperature data is available.

<img width="227" alt="Bildschirmfoto 2023-10-20 um 23 32 38" src="https://github.com/helgeerbe/OpenDTU-OnBattery/assets/3939346/6d2363fc-4f83-4b6f-a901-01469429b58b">
<img width="226" alt="Bildschirmfoto 2023-10-20 um 23 32 08" src="https://github.com/helgeerbe/OpenDTU-OnBattery/assets/3939346/c5a8c82d-3c44-493f-b41d-f0c07dbca857">
