### PR TITLE
Fix: VE.Direct refactor issues from #505

### DIFF
--- a/include/VictronMppt.h
+++ b/include/VictronMppt.h
@@ -25,6 +25,15 @@ public:
     // total output of all MPPT charge controllers in Watts
     int32_t getPowerOutputWatts() const;
 
+    // total panel input power of all MPPT charge controllers in Watts
+    int32_t getPanelPowerWatts() const;
+
+    // sum of total yield of all MPPT charge controllers in kWh
+    double getYieldTotal() const;
+
+    // sum of today's yield of all MPPT charge controllers in kWh
+    double getYieldDay() const;
+
 private:
     VictronMpptClass(VictronMpptClass const& other) = delete;
     VictronMpptClass(VictronMpptClass&& other) = delete;

--- a/src/VictronMppt.cpp
+++ b/src/VictronMppt.cpp
@@ -78,7 +78,7 @@ VeDirectMpptController::spData_t VictronMpptClass::getData(size_t idx) const
     if (_controllers.empty() || idx >= _controllers.size()) {
         MessageOutput.printf("ERROR: MPPT controller index %d is out of bounds (%d controllers)\r\n",
                 idx, _controllers.size());
-        return VeDirectMpptController::spData_t{};
+        return std::make_shared<VeDirectMpptController::veMpptStruct>();
     }
 
     return _controllers[idx]->getData();

--- a/src/VictronMppt.cpp
+++ b/src/VictronMppt.cpp
@@ -94,3 +94,36 @@ int32_t VictronMpptClass::getPowerOutputWatts() const
 
     return sum;
 }
+
+int32_t VictronMpptClass::getPanelPowerWatts() const
+{
+    int32_t sum = 0;
+
+    for (const auto& upController : _controllers) {
+        sum += upController->getData()->PPV;
+    }
+
+    return sum;
+}
+
+double VictronMpptClass::getYieldTotal() const
+{
+    double sum = 0;
+
+    for (const auto& upController : _controllers) {
+        sum += upController->getData()->H19;
+    }
+
+    return sum;
+}
+
+double VictronMpptClass::getYieldDay() const
+{
+    double sum = 0;
+
+    for (const auto& upController : _controllers) {
+        sum += upController->getData()->H20;
+    }
+
+    return sum;
+}

--- a/src/WebApi_ws_live.cpp
+++ b/src/WebApi_ws_live.cpp
@@ -192,10 +192,9 @@ void WebApiWsLiveClass::generateJsonResponse(JsonVariant& root)
     vedirectObj[F("enabled")] = Configuration.get().Vedirect_Enabled;
     JsonObject totalVeObj = vedirectObj.createNestedObject("total");
 
-    auto spMpptData = VictronMppt.getData();
-    addTotalField(totalVeObj, "Power", spMpptData->PPV, "W", 1);
-    addTotalField(totalVeObj, "YieldDay", spMpptData->H20 * 1000, "Wh", 0);
-    addTotalField(totalVeObj, "YieldTotal", spMpptData->H19, "kWh", 2);
+    addTotalField(totalVeObj, "Power", VictronMppt.getPanelPowerWatts(), "W", 1);
+    addTotalField(totalVeObj, "YieldDay", VictronMppt.getYieldDay() * 1000, "Wh", 0);
+    addTotalField(totalVeObj, "YieldTotal", VictronMppt.getYieldTotal(), "kWh", 2);
 
     JsonObject huaweiObj = root.createNestedObject("huawei");
     huaweiObj[F("enabled")] = Configuration.get().Huawei_Enabled;


### PR DESCRIPTION
The refactor in #505 was not tested with VE.Direct turned off. Sorry for that.

If VE.Direct is turned off, the web API implementation still adds totals of the MPPT to be displayed by the web app on the top. It used `VictronMppt.getData()`, which did print an error message on the console, but did not return the proper fallback data structure. It returned a `std::shared_ptr` pointing to `nullptr` rather than one pointing to a default-initialized MPPT data struct, which was my intention.

The fix is simple, see the first commit. However, the error message is still printed on the console, since the web API implementation adds the totals unconditionally. Adding them only if VE.Direct is enabled is not working out, since those values are defined to be part of the respective typescript type definition, so the web app crashes if those values are missing. Also, they would only add the values of the first MPPT controller. In the future, these totals should be the respective sum over all MPPT controller of these totals. Hence the second commit implements the respective methods. Using them instead of `VictronMppt.getData()` also gets rid of the error message in the log in case VE.Direct is disabled.

All other uses of `VictronMppt.getData()` are now safe, as was originally intended. However, (manual) access to `api/vedirectlivedata/status` will still print the aforementioned error message to the log. Changing this is not really possible (without further refactoring of the web app). The API endpoint should not respond with default-initialized values if the data is invalid or VE.Direct is not enabled. However, this was previously the case and will be the case now as well. This should be fixed once the liveview adds support for multiple MPPT charge controllers: The API endpoint will return a list of MPPT charge controller values, which will be empty if VE.Direct is disabled or the data is invalid.

Note that the aforementioned error message will not appear when accessing the live view, as the web app will not connect to the VE.Direct live view API endpoint if VE.Direct is disabled.