### PR TITLE
Huawei AC charger: prevent setting current limit when internal power control mode is enabled

### DIFF
--- a/include/Huawei_can.h
+++ b/include/Huawei_can.h
@@ -129,6 +129,7 @@ public:
 
 private:
     void processReceivedParameters();
+    void _setValue(float in, uint8_t parameterType);
 
     TaskHandle_t _HuaweiCanCommunicationTaskHdl = NULL;
     bool    _initialized = false;


### PR DESCRIPTION
The Huawei PSU currently allows setting current / voltage values externally when running in internal power control mode. This leads e.g. to current limits received via MQTT being applied for a brief time until they're being changed again by the power control in HuaweiCanClass. In my specific case I started to control the operation mode externally which resulted in frequent on/off switches.
This PR makes the original setValue method private (renamed to _setValue) and adds a new public setValue method that includes a check / rejects changes in this case.