### PR TITLE
Fix: move battery's lock_guard to updateSettings()

### DIFF
--- a/src/Battery.cpp
+++ b/src/Battery.cpp
@@ -26,13 +26,14 @@ void BatteryClass::init(Scheduler& scheduler)
     _loopTask.setCallback(std::bind(&BatteryClass::loop, this));
     _loopTask.setIterations(TASK_FOREVER);
     _loopTask.enable();
-    std::lock_guard<std::mutex> lock(_mutex);
 
     this->updateSettings();
 }
 
 void BatteryClass::updateSettings()
 {
+    std::lock_guard<std::mutex> lock(_mutex);
+
     if (_upProvider) {
         _upProvider->deinit();
         _upProvider = nullptr;


### PR DESCRIPTION
the updateSettings method is called from the web server's context and therefore accesses _upProvider in a different context than the TaskScheduler. the lock_guard needs to protect _upProvider.