### PR TITLE
Fix: use FormFooter in OnBattery-specific forms

### DIFF
--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -31,6 +31,7 @@
         "Yes": "Ja",
         "No": "Nein",
         "VerboseLogging": "Ausführliche Protokollierung",
+        "Seconds": "Sekunden",
         "Loading": "Lade...",
         "Reload": "Aktualisieren",
         "Cancel": "Abbrechen",
@@ -519,8 +520,7 @@
         "EnableVedirect": "Aktiviere VE.Direct",
         "VedirectParameter": "VE.Direct Parameter",
         "VerboseLogging": "@:base.VerboseLogging",
-        "UpdatesOnly": "Werte nur bei Änderung an MQTT broker senden",
-        "Save": "@:dtuadmin.Save"
+        "UpdatesOnly": "Werte nur bei Änderung an MQTT broker senden"
     },
     "powermeteradmin":{
         "PowerMeterSettings": "Stromzähler Einstellungen",
@@ -541,7 +541,6 @@
         "SDM": "SDM-Stromzähler Konfiguration",
         "sdmbaudrate": "Baudrate",
         "sdmaddress": "Modbus Adresse",
-        "Save": "@:dtuadmin.Save",
         "HTTP": "HTTP(S) + JSON - Allgemeine Konfiguration",
         "httpIndividualRequests": "Individuelle HTTP requests pro Phase",
         "httpUrlDescription": "Die URL muss mit http:// oder https:// beginnen. Manche Zeichen wie Leerzeichen und = müssen mit URL-Kodierung kodiert werden (%xx). Achtung: Ein Überprüfung von SSL Server Zertifikaten ist nicht implementiert (MITM-Attacken sind möglich)! Beispiele gibt es unten.",
@@ -596,8 +595,7 @@
         "VoltageLoadCorrectionInfo": "<b>Hinweis:</b> Wenn Leistung von der Batterie abgegeben wird, bricht normalerweise die Spannung etwas ein. Damit nicht vorzeitig der Wechelrichter ausgeschaltet wird sobald der \"Stop\"-Schwellenwert erreicht wird, wird der hier angegebene Korrekturfaktor mit einberechnet. Korrigierte Spannung = DC Spannung + (Aktuelle Leistung (W) * Korrekturfaktor).",
         "InverterRestart": "Wechselrichter Neustart",
         "InverterRestartHour": "Stunde für Neustart",
-        "InverterRestartHint": "Neustart des Wechselrichter einmal täglich um die \"Tagesertrag\" Werte wieder auf Null zu setzen.",
-        "Save": "@:dtuadmin.Save"
+        "InverterRestartHint": "Neustart des Wechselrichter einmal täglich um die \"Tagesertrag\" Werte wieder auf Null zu setzen."
     },
     "batteryadmin": {
         "BatterySettings": "Batterie Einstellungen",
@@ -613,8 +611,7 @@
         "JkBmsInterfaceUart": "TTL-UART an der MCU",
         "JkBmsInterfaceTransceiver": "RS-485 Transceiver an der MCU",
         "PollingInterval": "Abfrageintervall",
-        "Seconds": "@:dtuadmin.Seconds",
-        "Save": "@:dtuadmin.Save"
+        "Seconds": "@:base.Seconds"
     },
     "inverteradmin": {
         "InverterSettings": "Wechselrichter Einstellungen",
@@ -800,8 +797,7 @@
         "enableVoltageLimitHint": "Die automatische Leistungssteuerung wird deaktiviert wenn die Ausgangsspannung über diesem Wert liegt und wenn gleichzeitig die Ausgangsleistung unter die minimale Leistung fällt.\nDie automatische Leistungssteuerung wird re-aktiveiert wenn die Batteriespannung unter diesen Wert fällt.",
         "lowerPowerLimit": "Minimale Leistung",
         "upperPowerLimit": "Maximale Leistung",
-        "Seconds": "@:dtuadmin.Seconds",
-        "Save": "@:dtuadmin.Save"
+        "Seconds": "@:base.Seconds"
       },
       "battery": {
         "battery": "Batterie",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -31,6 +31,7 @@
         "Yes": "Yes",
         "No": "No",
         "VerboseLogging": "Verbose Logging",
+        "Seconds": "Seconds",
         "Loading": "Loading...",
         "Reload": "Reload",
         "Cancel": "Cancel",
@@ -521,8 +522,7 @@
         "EnableVedirect": "Enable VE.Direct",
         "VedirectParameter": "VE.Direct Parameter",
         "VerboseLogging": "@:base.VerboseLogging",
-        "UpdatesOnly": "Publish values to MQTT only when they change",
-        "Save": "@:dtuadmin.Save"
+        "UpdatesOnly": "Publish values to MQTT only when they change"
     },
     "powermeteradmin":{
         "PowerMeterSettings": "Power Meter Settings",
@@ -543,7 +543,6 @@
         "SDM": "SDM-Power Meter Parameter",
         "sdmbaudrate": "Baudrate",
         "sdmaddress": "Modbus Address",
-        "Save": "@:dtuadmin.Save",
         "HTTP": "HTTP(S) + Json - General configuration",
         "httpIndividualRequests": "Individual HTTP requests per phase",
         "httpPhase": "HTTP(S) + Json configuration - Phase {phaseNumber}",
@@ -605,8 +604,7 @@
         "VoltageLoadCorrectionInfo": "<b>Hint:</b> When the power output is higher, the voltage is usually decreasing. In order to not stop the inverter too early (Stop treshold), a power factor can be specified here to correct this. Corrected voltage = DC Voltage + (Current power * correction factor).",
         "InverterRestart": "Inverter Restart",
         "InverterRestartHour": "Restart Hour",
-        "InverterRestartHint": "Restart the Inverter once a day to reset the \"YieldDay\" values.",
-        "Save": "@:dtuadmin.Save"
+        "InverterRestartHint": "Restart the Inverter once a day to reset the \"YieldDay\" values."
     },
     "batteryadmin": {
         "BatterySettings": "Battery Settings",
@@ -622,8 +620,7 @@
         "JkBmsInterfaceUart": "TTL-UART on MCU",
         "JkBmsInterfaceTransceiver": "RS-485 Transceiver on MCU",
         "PollingInterval": "Polling Interval",
-        "Seconds": "@:dtuadmin.Seconds",
-        "Save": "@:dtuadmin.Save"
+        "Seconds": "@:base.Seconds"
     },
     "inverteradmin": {
         "InverterSettings": "Inverter Settings",
@@ -810,8 +807,7 @@
         "enableVoltageLimitHint": "Automatic power control is disabled if the output voltage is higher then this value and if the output power drops below the minimum output power limit (set below).\nAutomatic power control is re-enabled if the battery voltage drops below the value set in this field.",
         "lowerPowerLimit": "Minimum output power",
         "upperPowerLimit": "Maximum output power",
-        "Seconds": "@:dtuadmin.Seconds",
-        "Save": "@:dtuadmin.Save"
+        "Seconds": "@:base.Seconds"
       },
       "battery": {
         "battery": "Battery",

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -31,6 +31,7 @@
         "Yes": "Oui",
         "No": "Non",
         "VerboseLogging": "Journalisation Détaillée",
+        "Seconds": "Secondes",
         "Loading": "Chargement...",
         "Reload": "Reload",
         "Cancel": "Annuler",
@@ -521,8 +522,7 @@
         "EnableVedirect": "Enable VE.Direct",
         "VedirectParameter": "VE.Direct Parameter",
         "VerboseLogging": "@:base.VerboseLogging",
-        "UpdatesOnly": "Publish values to MQTT only when they change",
-        "Save": "@:dtuadmin.Save"
+        "UpdatesOnly": "Publish values to MQTT only when they change"
     },
     "batteryadmin": {
         "BatterySettings": "Battery Settings",
@@ -538,8 +538,7 @@
         "JkBmsInterfaceUart": "TTL-UART on MCU",
         "JkBmsInterfaceTransceiver": "RS-485 Transceiver on MCU",
         "PollingInterval": "Polling Interval",
-        "Seconds": "@:dtuadmin.Seconds",
-        "Save": "@:dtuadmin.Save"
+        "Seconds": "@:base.Seconds"
     },
     "inverteradmin": {
         "InverterSettings": "Paramètres des onduleurs",
@@ -648,8 +647,7 @@
       "BatterySocInfo": "<b>Hint:</b> The battery SoC (State of Charge) values can only be used if the battery communication interface is enabled. If the battery has not reported any SoC updates in the last minute, the voltage thresholds will be used as fallback.",
       "InverterIsBehindPowerMeter": "Inverter is behind Power meter",
       "Battery": "DC / Battery",
-      "VoltageLoadCorrectionInfo": "<b>Hint:</b> When the power output is higher, the voltage is usually decreasing. In order to not stop the inverter too early (Stop treshold), a power factor can be specified here to correct this. Corrected voltage = DC Voltage + (Current power * correction factor).",
-      "Save": "@:dtuadmin.Save"
+      "VoltageLoadCorrectionInfo": "<b>Hint:</b> When the power output is higher, the voltage is usually decreasing. In order to not stop the inverter too early (Stop treshold), a power factor can be specified here to correct this. Corrected voltage = DC Voltage + (Current power * correction factor)."
     },
     "login": {
         "Login": "Connexion",
@@ -768,8 +766,7 @@
         "enableVoltageLimitHint": "Automatic power control is disabled if the output voltage is higher then this value and if the output power drops below the minimum output power limit (set below).\nAutomatic power control is re-enabled if the battery voltage drops below the value set in this field.",
         "lowerPowerLimit": "Minimum output power",
         "upperPowerLimit": "Maximum output power",
-        "Seconds": "@:dtuadmin.Seconds",
-        "Save": "@:dtuadmin.Save"
+        "Seconds": "@:base.Seconds"
       },
       "battery": {
         "battery": "Battery",

--- a/webapp/src/views/AcChargerAdminView.vue
+++ b/webapp/src/views/AcChargerAdminView.vue
@@ -73,7 +73,7 @@
                 </CardElement>
             </CardElement>
 
-            <button type="submit" class="btn btn-primary mb-3">{{ $t('acchargeradmin.Save') }}</button>
+            <FormFooter @reload="getChargerConfig"/>
         </form>
     </BasePage>
 </template>
@@ -82,6 +82,7 @@
 import BasePage from '@/components/BasePage.vue';
 import BootstrapAlert from "@/components/BootstrapAlert.vue";
 import CardElement from '@/components/CardElement.vue';
+import FormFooter from '@/components/FormFooter.vue';
 import InputElement from '@/components/InputElement.vue';
 import { BIconInfoCircle } from 'bootstrap-icons-vue';
 import type { AcChargerConfig } from "@/types/AcChargerConfig";
@@ -93,6 +94,7 @@ export default defineComponent({
         BasePage,
         BootstrapAlert,
         CardElement,
+        FormFooter,
         InputElement,
         BIconInfoCircle,
     },

--- a/webapp/src/views/BatteryAdminView.vue
+++ b/webapp/src/views/BatteryAdminView.vue
@@ -49,7 +49,7 @@
                               type="number" min="2" max="90" step="1" :postfix="$t('batteryadmin.Seconds')"/>
             </CardElement>
 
-            <button type="submit" class="btn btn-primary mb-3">{{ $t('batteryadmin.Save') }}</button>
+            <FormFooter @reload="getBatteryConfig"/>
         </form>
     </BasePage>
 </template>
@@ -58,6 +58,7 @@
 import BasePage from '@/components/BasePage.vue';
 import BootstrapAlert from "@/components/BootstrapAlert.vue";
 import CardElement from '@/components/CardElement.vue';
+import FormFooter from '@/components/FormFooter.vue';
 import InputElement from '@/components/InputElement.vue';
 import type { BatteryConfig } from "@/types/BatteryConfig";
 import { authHeader, handleResponse } from '@/utils/authentication';
@@ -68,6 +69,7 @@ export default defineComponent({
         BasePage,
         BootstrapAlert,
         CardElement,
+        FormFooter,
         InputElement,
     },
     data() {

--- a/webapp/src/views/PowerLimiterAdminView.vue
+++ b/webapp/src/views/PowerLimiterAdminView.vue
@@ -265,7 +265,7 @@
                 </div>
             </CardElement>
 
-            <button type="submit" class="btn btn-primary mb-3">{{ $t('powerlimiteradmin.Save') }}</button>
+            <FormFooter @reload="getPowerLimiterConfig"/>
         </form>
     </BasePage>
 </template>
@@ -276,6 +276,7 @@ import BasePage from '@/components/BasePage.vue';
 import BootstrapAlert from "@/components/BootstrapAlert.vue";
 import { handleResponse, authHeader } from '@/utils/authentication';
 import CardElement from '@/components/CardElement.vue';
+import FormFooter from '@/components/FormFooter.vue';
 import InputElement from '@/components/InputElement.vue';
 import { BIconInfoCircle } from 'bootstrap-icons-vue';
 import type { PowerLimiterConfig } from "@/types/PowerLimiterConfig";
@@ -285,6 +286,7 @@ export default defineComponent({
         BasePage,
         BootstrapAlert,
         CardElement,
+        FormFooter,
         InputElement,
         BIconInfoCircle,
     },

--- a/webapp/src/views/PowerMeterAdminView.vue
+++ b/webapp/src/views/PowerMeterAdminView.vue
@@ -185,7 +185,7 @@
                 </div>
             </div>
 
-            <button type="submit" class="btn btn-primary mb-3">{{ $t('powermeteradmin.Save') }}</button>
+            <FormFooter @reload="getPowerMeterConfig"/>
 
             <div v-if="powerMeterConfigList.source === 3" class="alert alert-secondary" role="alert">
                 <h2>URL examples:</h2>
@@ -213,6 +213,7 @@ import { defineComponent } from 'vue';
 import BasePage from '@/components/BasePage.vue';
 import BootstrapAlert from "@/components/BootstrapAlert.vue";
 import CardElement from '@/components/CardElement.vue';
+import FormFooter from '@/components/FormFooter.vue';
 import InputElement from '@/components/InputElement.vue';
 import { handleResponse, authHeader } from '@/utils/authentication';
 import type { PowerMeterHttpPhaseConfig, PowerMeterConfig } from "@/types/PowerMeterConfig";
@@ -222,6 +223,7 @@ export default defineComponent({
         BasePage,
         BootstrapAlert,
         CardElement,
+        FormFooter,
         InputElement
     },
     data() {

--- a/webapp/src/views/VedirectAdminView.vue
+++ b/webapp/src/views/VedirectAdminView.vue
@@ -23,7 +23,7 @@
                               type="checkbox" wide/>
             </CardElement>
 
-            <button type="submit" class="btn btn-primary mb-3">{{ $t('vedirectadmin.Save') }}</button>
+            <FormFooter @reload="getVedirectConfig"/>
         </form>
     </BasePage>
 </template>
@@ -32,6 +32,7 @@
 import BasePage from '@/components/BasePage.vue';
 import BootstrapAlert from "@/components/BootstrapAlert.vue";
 import CardElement from '@/components/CardElement.vue';
+import FormFooter from '@/components/FormFooter.vue';
 import InputElement from '@/components/InputElement.vue';
 import type { VedirectConfig } from "@/types/VedirectConfig";
 import { authHeader, handleResponse } from '@/utils/authentication';
@@ -42,6 +43,7 @@ export default defineComponent({
         BasePage,
         BootstrapAlert,
         CardElement,
+        FormFooter,
         InputElement,
     },
     data() {


### PR DESCRIPTION
the upstream project introduced a new Vue component "FormFooter", which is used to end an input form, namely all settings forms. we should not only use this component as well, but the save button on our forms actually broke since the text dtuadmin.Save is replaced by base.Save.

also replace the use of dtuadmin.Seconds with base.Seconds, such that an upstream change to dtuadmin.Seconds will not break the battery admin an AC charger views.

closes #568.