### PR TITLE
Fix: switch context when processing DPL MQTT requests

### DIFF
--- a/include/MqttHandlePowerLimiter.h
+++ b/include/MqttHandlePowerLimiter.h
@@ -4,6 +4,9 @@
 #include "Configuration.h"
 #include <espMqttClient.h>
 #include <TaskSchedulerDeclarations.h>
+#include <mutex>
+#include <deque>
+#include <functional>
 
 class MqttHandlePowerLimiterClass {
 public:
@@ -18,6 +21,11 @@ private:
     uint32_t _lastPublishStats;
     uint32_t _lastPublish;
 
+    // MQTT callbacks to process updates on subscribed topics are executed in
+    // the MQTT thread's context. we use this queue to switch processing the
+    // user requests into the main loop's context (TaskScheduler context).
+    mutable std::mutex _mqttMutex;
+    std::deque<std::function<void()>> _mqttCallbacks;
 };
 
 extern MqttHandlePowerLimiterClass MqttHandlePowerLimiter;


### PR DESCRIPTION
MQTT message callbacks are executed in the MQTT thread context. when processing topics that control the DPL, we must avoid executing methods that are not thread-safe. this change binds the methods to be called to the respective parameters and executes them in the TaskScheduler context, such that they no longer need to be thread-safe.