### PR TITLE
Enhanced MQTT Data for Serial Battery Configuration

### DIFF
--- a/include/BatteryStats.h
+++ b/include/BatteryStats.h
@@ -159,6 +159,8 @@ class VictronSmartShuntStats : public BatteryStats {
         float _dischargedEnergy;
         String _modelName;
         int32_t _instantaneousPower;
+        float _midpointVoltage;
+        float _midpointDeviation;
         float _consumedAmpHours;
         int32_t _lastFullCharge;
 

--- a/lib/VeDirectFrameHandler/VeDirectData.h
+++ b/lib/VeDirectFrameHandler/VeDirectData.h
@@ -79,6 +79,8 @@ struct veShuntStruct : veStruct {
     int32_t H16;                    // Maximum auxiliary (battery) voltage
     int32_t H17;                    // Amount of discharged energy
     int32_t H18;                    // Amount of charged energy
+    int32_t VM;                     // Mid-point voltage of the battery bank
+    int32_t DM;                     // Mid-point deviation of the battery bank
     int8_t dcMonitorMode_MON;       // DC monitor mode
 };
 

--- a/lib/VeDirectFrameHandler/VeDirectShuntController.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectShuntController.cpp
@@ -108,6 +108,14 @@ bool VeDirectShuntController::processTextDataDerived(std::string const& name, st
 		_tmpFrame.H17 = atoi(value.c_str());
 		return true;
 	}
+	if (name == "VM") {
+		_tmpFrame.VM = atoi(value.c_str());
+		return true;
+	}
+	if (name == "DM") {
+		_tmpFrame.DM = atoi(value.c_str());
+		return true;
+	}
 	if (name == "H18") {
 		_tmpFrame.H18 = atoi(value.c_str());
 		return true;

--- a/src/BatteryStats.cpp
+++ b/src/BatteryStats.cpp
@@ -391,6 +391,8 @@ void VictronSmartShuntStats::updateFrom(VeDirectShuntController::data_t const& s
     _manufacturer = "Victron " + _modelName;
     _temperature = shuntData.T;
     _tempPresent = shuntData.tempPresent;
+    _midpointVoltage = static_cast<float>(shuntData.VM) / 1000;
+    _midpointDeviation = static_cast<float>(shuntData.DM) / 10;
     _instantaneousPower = shuntData.P;
     _consumedAmpHours = static_cast<float>(shuntData.CE) / 1000;
     _lastFullCharge = shuntData.H9 / 60;
@@ -414,6 +416,8 @@ void VictronSmartShuntStats::getLiveViewData(JsonVariant& root) const {
     addLiveViewValue(root, "dischargedEnergy", _dischargedEnergy, "kWh", 2);
     addLiveViewValue(root, "instantaneousPower", _instantaneousPower, "W", 0);
     addLiveViewValue(root, "consumedAmpHours", _consumedAmpHours, "Ah", 3);
+    addLiveViewValue(root, "midpointVoltage", _midpointVoltage, "V", 2);
+    addLiveViewValue(root, "midpointDeviation", _midpointDeviation, "%", 1);
     addLiveViewValue(root, "lastFullCharge", _lastFullCharge, "min", 0);
     if (_tempPresent) {
         addLiveViewValue(root, "temperature", _temperature, "°C", 0);
@@ -436,4 +440,6 @@ void VictronSmartShuntStats::mqttPublish() const {
     MqttSettings.publish("battery/instantaneousPower", String(_instantaneousPower));
     MqttSettings.publish("battery/consumedAmpHours", String(_consumedAmpHours));
     MqttSettings.publish("battery/lastFullCharge", String(_lastFullCharge));
+    MqttSettings.publish("battery/midpointVoltage", String(_midpointVoltage));
+    MqttSettings.publish("battery/midpointDeviation", String(_midpointDeviation));
 }

--- a/src/MqttHandleBatteryHass.cpp
+++ b/src/MqttHandleBatteryHass.cpp
@@ -120,6 +120,8 @@ void MqttHandleBatteryHassClass::loop()
             publishSensor("Charge Cycles", "mdi:counter", "chargeCycles");
             publishSensor("Consumed Amp Hours", NULL, "consumedAmpHours", NULL, "measurement", "Ah");
             publishSensor("Last Full Charge", "mdi:timelapse", "lastFullCharge", NULL, NULL, "min");
+            publishSensor("Midpoint Voltage", NULL, "midpointVoltage", "voltage", "measurement", "V");
+            publishSensor("Midpoint Deviation", NULL, "midpointDeviation", "battery", "measurement", "%");
             break;
     }
 

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -942,6 +942,8 @@
         "dischargedEnergy": "Entladene Energie",
         "instantaneousPower": "Aktuelle Leistung",
         "consumedAmpHours": "Verbrauchte Amperestunden",
+        "midpointVoltage": "Mittelpunktspannung",
+        "midpointDeviation": "Mittelpunktsabweichung",
         "lastFullCharge": "Letztes mal Vollgeladen"
     }
 }

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -949,6 +949,8 @@
         "dischargedEnergy": "Discharged energy",
         "instantaneousPower": "Instantaneous Power",
         "consumedAmpHours": "Consumed Amp Hours",
+        "midpointVoltage": "Midpoint Voltage",
+        "midpointDeviation": "Midpoint Deviation",
         "lastFullCharge": "Last full Charge"
     }
 }

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -934,6 +934,8 @@
         "dischargedEnergy": "Discharged energy",
         "instantaneousPower": "Instantaneous Power",
         "consumedAmpHours": "Consumed Amp Hours",
+        "midpointVoltage": "Midpoint Voltage",
+        "midpointDeviation": "Midpoint Deviation",
         "lastFullCharge": "Last full Charge"
     }
 }


### PR DESCRIPTION
I'm excited to share my first pull request, which focuses on enriching the MQTT data for batteries in a serial configuration. This enhancement includes not only additional data fields but also improves the decimal accuracy for both live view displayed data and MQTT transmissions.

### Changes Made:

**New Data Fields for HomeAssistant MQTT Auto Discovery:**

1. Midpoint Voltage:
- Added midpoint voltage information to provide a more comprehensive view of the battery's state in a serial configuration.

2. Midpoint Deviation:
- Introduced the midpoint deviation metric, offering insights into the balance and stability of the battery pack.

3. Additional Metrics:
- Consumed Ampere Hours: Tracking the total ampere hours consumed over time.
- Instantaneous Power: Providing real-time power consumption data for more immediate insights.
- Charged Energy: Monitoring the total energy charged into the battery.
- Discharged Energy: Keeping tabs on the energy discharged from the battery.

**Decimal Accuracy Improvement:**
To enhance precision, the decimal accuracy for both live view and MQTT-transmitted Smartshunt data has been increased. 