### PR TITLE
avoid too frequent SmartShunt data copies

### DIFF
--- a/include/VictronSmartShunt.h
+++ b/include/VictronSmartShunt.h
@@ -11,6 +11,7 @@ public:
     std::shared_ptr<BatteryStats> getStats() const final { return _stats; }
 
 private:
+    uint32_t _lastUpdate = 0;
     std::shared_ptr<VictronSmartShuntStats> _stats =
         std::make_shared<VictronSmartShuntStats>();
 };

--- a/src/VictronSmartShunt.cpp
+++ b/src/VictronSmartShunt.cpp
@@ -28,5 +28,9 @@ bool VictronSmartShunt::init(bool verboseLogging)
 void VictronSmartShunt::loop()
 {
     VeDirectShunt.loop();
+
+    if (VeDirectShunt.getLastUpdate() <= _lastUpdate) { return; }
+
     _stats->updateFrom(VeDirectShunt.veFrame);
+    _lastUpdate = VeDirectShunt.getLastUpdate();
 }


### PR DESCRIPTION
currently the whole SmartShunt data structure is copied to the BatteryStats instance in every loop, even though the data cannot possibly have changed. this is quite an expensive task to do in every loop. this change tracks the last update timestamp and only does the copy operation if an actual updated data structure was received from the smart shunt.