### PR TITLE
Feature: show power grid usage on display

### DIFF
--- a/src/Display_Graphic.cpp
+++ b/src/Display_Graphic.cpp
@@ -67,11 +67,19 @@ void DisplayGraphicClass::init(Scheduler& scheduler, const DisplayType_t type, c
 
 void DisplayGraphicClass::calcLineHeights()
 {
-    uint8_t yOff = 0;
+    bool diagram = (_isLarge && _diagram_mode == DiagramMode_t::Small);
+    // the diagram needs space. we need to keep
+    // away from the y-axis label in particular.
+    uint8_t yOff = (diagram?7:0);
     for (uint8_t i = 0; i < 4; i++) {
         setFont(i);
-        yOff += (_display->getMaxCharHeight());
+        yOff += _display->getAscent();
         _lineOffsets[i] = yOff;
+        yOff += ((!_isLarge || diagram)?2:3);
+        // the descent is a negative value and moves the *next* line's
+        // baseline. the first line never uses a letter with descent and
+        // we need that space when showing the small diagram.
+        yOff -= ((i == 0 && diagram)?0:_display->getDescent());
     }
 }
 

--- a/src/WebApi_device.cpp
+++ b/src/WebApi_device.cpp
@@ -184,12 +184,12 @@ void WebApiDeviceClass::onDeviceAdminPost(AsyncWebServerRequest* request)
         config.Led_Single[i].Brightness = min<uint8_t>(100, config.Led_Single[i].Brightness);
     }
 
+    Display.setDiagramMode(static_cast<DiagramMode_t>(config.Display.Diagram.Mode));
     Display.setOrientation(config.Display.Rotation);
     Display.enablePowerSafe = config.Display.PowerSafe;
     Display.enableScreensaver = config.Display.ScreenSaver;
     Display.setContrast(config.Display.Contrast);
     Display.setLanguage(config.Display.Language);
-    Display.setDiagramMode(static_cast<DiagramMode_t>(config.Display.Diagram.Mode));
     Display.Diagram().updatePeriod();
 
     WebApi.writeConfig(retMsg);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -135,12 +135,12 @@ void setup()
         pin.display_clk,
         pin.display_cs,
         pin.display_reset);
+    Display.setDiagramMode(static_cast<DiagramMode_t>(config.Display.Diagram.Mode));
     Display.setOrientation(config.Display.Rotation);
     Display.enablePowerSafe = config.Display.PowerSafe;
     Display.enableScreensaver = config.Display.ScreenSaver;
     Display.setContrast(config.Display.Contrast);
     Display.setLanguage(config.Display.Language);
-    Display.setDiagramMode(static_cast<DiagramMode_t>(config.Display.Diagram.Mode));
     Display.setStartupDisplay();
     MessageOutput.println("done");
 


### PR DESCRIPTION
if the power meter is enabled, the display will use two of three out of every three-second time slot to show the grid consumption.

closes #620.

This was fun and I like the result, but it took way too much time. Fiddling with the display is much more time consuming as one might think. At least it was in this instance for me.

The display shows this screen for three seconds:
![image](https://github.com/helgeerbe/OpenDTU-OnBattery/assets/3578416/ad727edd-bde7-4e86-aa9d-a9b61c6101d5)

This one for another three seconds (last line changes ever three seconds):
![image](https://github.com/helgeerbe/OpenDTU-OnBattery/assets/3578416/be44ff24-76c4-4f3d-895e-bf29f5ff74a2)

The third out of three three-second time slots will still show the total yield (if this was the actual successor screen of the frame above, it would show the date and time in the last line...):
![image](https://github.com/helgeerbe/OpenDTU-OnBattery/assets/3578416/363f5297-b702-402b-95b8-10553ed402cf)

Works for French as well (the word "reseau" is quite long):
![image](https://github.com/helgeerbe/OpenDTU-OnBattery/assets/3578416/bf90b3f2-e033-48cd-b70a-427d39e94dec)
![image](https://github.com/helgeerbe/OpenDTU-OnBattery/assets/3578416/6d4d3016-b335-428b-8082-64cb126ddfb3)

I made sure that it works for small display as well:
![image](https://github.com/helgeerbe/OpenDTU-OnBattery/assets/3578416/3d16bd5a-d44d-4d4c-be7e-ff5ddbec9ca4)

Changes were made to the calculation of the text baselines, which I think were wrong and lead to space being wasted. Those changes will be proposed upstream as well.

This PR supersedes #644. Thanks @spcqike and @thinklerde for your feedback.