### PR TITLE
Fix: make text of total production fit displays

### DIFF
--- a/src/Display_Graphic.cpp
+++ b/src/Display_Graphic.cpp
@@ -33,6 +33,7 @@ static const char* const i18n_current_power_w[] = { "%.0f W", "%.0f W", "%.0f W"
 static const char* const i18n_current_power_kw[] = { "%.1f kW", "%.1f kW", "%.1f kW" };
 static const char* const i18n_yield_today_wh[] = { "today: %4.0f Wh", "Heute: %4.0f Wh", "auj.: %4.0f Wh" };
 static const char* const i18n_yield_total_kwh[] = { "total: %.1f kWh", "Ges.: %.1f kWh", "total: %.1f kWh" };
+static const char* const i18n_yield_total_mwh[] = { "total: %.0f kWh", "Ges.: %.0f kWh", "total: %.0f kWh" };
 static const char* const i18n_date_format[] = { "%m/%d/%Y %H:%M", "%d.%m.%Y %H:%M", "%d/%m/%Y %H:%M" };
 
 DisplayGraphicClass::DisplayGraphicClass()
@@ -236,7 +237,9 @@ void DisplayGraphicClass::loop()
         snprintf(_fmtText, sizeof(_fmtText), i18n_yield_today_wh[_display_language], Datastore.getTotalAcYieldDayEnabled());
         printText(_fmtText, 1);
 
-        snprintf(_fmtText, sizeof(_fmtText), i18n_yield_total_kwh[_display_language], Datastore.getTotalAcYieldTotalEnabled());
+        const float watts = Datastore.getTotalAcYieldTotalEnabled();
+        auto const format = (watts >= 1000)?i18n_yield_total_mwh:i18n_yield_total_kwh;
+        snprintf(_fmtText, sizeof(_fmtText), format[_display_language], watts);
         printText(_fmtText, 2);
         //<=======================
 


### PR DESCRIPTION
in case the total production is larger than 1 MWh, i.e., 1000 kWh, the text on the respective line becomes too large such that it reaches out of the display when the screensaver is enabled.

this happens on the small and large displays.

![image](https://github.com/helgeerbe/OpenDTU-OnBattery/assets/3578416/e4411a0d-ebea-4525-88f7-a4d23d8e54c4)

this change switches the number format to a float without decimal places if the total production is larger or equal to 1000 kWh. this saves a dot and a digit, making the text short enough to fit the display even when the screensaver moved the display contents as far to the right as it does.