### PR TITLE
Feature: DPL: implement mode 3

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -30,7 +30,8 @@ public:
     enum class Status : unsigned {
         Initializing,
         DisabledByConfig,
-        DisabledByMqtt,
+        DisabledByMqttWithShutdown,
+        DisabledByMqttWithUnlimitedInverter,
         WaitingForValidTimestamp,
         PowerMeterDisabled,
         PowerMeterTimeout,
@@ -55,8 +56,9 @@ public:
 
     enum class Mode : unsigned {
         Normal = 0,
-        Disabled = 1,
-        UnconditionalFullSolarPassthrough = 2
+        DisabledShutdown = 1,
+        UnconditionalFullSolarPassthrough = 2,
+        DisabledUnlimited = 3
     };
 
     void setMode(Mode m) { _mode = m; }

--- a/src/MqttHandlePowerLimiter.cpp
+++ b/src/MqttHandlePowerLimiter.cpp
@@ -78,15 +78,20 @@ void MqttHandlePowerLimiterClass::onCmdMode(const espMqttClientTypes::MessagePro
 
     using Mode = PowerLimiterClass::Mode;
     switch (static_cast<Mode>(intValue)) {
+        case Mode::DisabledUnlimited:
+            MessageOutput.println("Power limiter disabled with inverter power unlimited");
+            _mqttCallbacks.push_back(std::bind(&PowerLimiterClass::setMode,
+                        &PowerLimiter, Mode::DisabledUnlimited));
+            break;
         case Mode::UnconditionalFullSolarPassthrough:
             MessageOutput.println("Power limiter unconditional full solar PT");
             _mqttCallbacks.push_back(std::bind(&PowerLimiterClass::setMode,
                         &PowerLimiter, Mode::UnconditionalFullSolarPassthrough));
             break;
-        case Mode::Disabled:
-            MessageOutput.println("Power limiter disabled (override)");
+        case Mode::DisabledShutdown:
+            MessageOutput.println("Power limiter disabled with inverter shutdown");
             _mqttCallbacks.push_back(std::bind(&PowerLimiterClass::setMode,
-                        &PowerLimiter, Mode::Disabled));
+                        &PowerLimiter, Mode::DisabledShutdown));
             break;
         case Mode::Normal:
             MessageOutput.println("Power limiter normal operation");


### PR DESCRIPTION
in this mode, the DPL is essentially disabled, but it keeps the inverter at 100% power output. this can be useful if one wants to adjust a load to the available solar power, rather than the other way around.