### PR TITLE
pull requests: use a meaningful branch when building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,15 @@ jobs:
       - name: Get tags
         run: git fetch --force --tags origin
 
+      - name: Create and switch to a meaningful branch for pull-requests
+        if: github.event_name == 'pull_request'
+        run: |
+          OWNER=${{ github.repository_owner }}
+          NAME=${{ github.event.repository.name }}
+          ID=${{ github.event.pull_request.number }}
+          DATE=$(date +'%Y%m%d%H%M')
+          git switch -c ${OWNER}/${NAME}/pr${ID}-${DATE}
+
       - name: Cache pip
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
This change makes the build runner switch to a meaningful branch name, which will then appear as the "Firmware Branch" in the System Info of the web application. This helps users testing pull-request builds identify that they are actually using the changes from the respective pull request.

Tested successfully on my own fork, see https://github.com/schlimmchen/OpenDTU-OnBattery/actions/runs/8133322818?pr=11

![image](https://github.com/helgeerbe/OpenDTU-OnBattery/assets/3578416/23624954-41f9-4038-9184-b70c8f14c7e6)
