### PR TITLE
Decoupled live view intervals

### DIFF
--- a/include/BatteryStats.h
+++ b/include/BatteryStats.h
@@ -15,7 +15,7 @@ class BatteryStats {
 
         // the last time *any* datum was updated
         uint32_t getAgeSeconds() const { return (millis() - _lastUpdate) / 1000; }
-        bool updateAvailable(uint32_t since) const { return _lastUpdate > since; }
+        bool updateAvailable(uint32_t since) const;
 
         uint8_t getSoC() const { return _soc; }
         uint32_t getSoCAgeSeconds() const { return (millis() - _lastUpdateSoC) / 1000; }

--- a/include/WebApi_ws_live.h
+++ b/include/WebApi_ws_live.h
@@ -17,6 +17,9 @@ private:
     static void generateInverterChannelJsonResponse(JsonObject& root, std::shared_ptr<InverterAbstract> inv);
     static void generateCommonJsonResponse(JsonVariant& root);
 
+    void generateOnBatteryJsonResponse(JsonVariant& root, bool all);
+    void sendOnBatteryStats();
+
     static void addField(JsonObject& root, std::shared_ptr<InverterAbstract> inv, const ChannelType_t type, const ChannelNum_t channel, const FieldId_t fieldId, String topic = "");
     static void addTotalField(JsonObject& root, const String& name, const float value, const String& unit, const uint8_t digits);
 
@@ -24,6 +27,12 @@ private:
     void onWebsocketEvent(AsyncWebSocket* server, AsyncWebSocketClient* client, AwsEventType type, void* arg, uint8_t* data, size_t len);
 
     AsyncWebSocket _ws;
+
+    uint32_t _lastPublishOnBatteryFull = 0;
+    uint32_t _lastPublishVictron = 0;
+    uint32_t _lastPublishHuawei = 0;
+    uint32_t _lastPublishBattery = 0;
+    uint32_t _lastPublishPowerMeter = 0;
 
     uint32_t _lastPublishStats[INV_MAX_COUNT] = { 0 };
 

--- a/src/BatteryStats.cpp
+++ b/src/BatteryStats.cpp
@@ -51,6 +51,12 @@ static void addLiveViewAlarm(JsonVariant& root, std::string const& name,
     root["issues"][name] = 2;
 }
 
+bool BatteryStats::updateAvailable(uint32_t since) const
+{
+    auto constexpr halfOfAllMillis = std::numeric_limits<uint32_t>::max() / 2;
+    return (_lastUpdate - since) < halfOfAllMillis;
+}
+
 void BatteryStats::getLiveViewData(JsonVariant& root) const
 {
     root[F("manufacturer")] = _manufacturer;

--- a/webapp/src/views/HomeView.vue
+++ b/webapp/src/views/HomeView.vue
@@ -461,12 +461,16 @@ export default defineComponent({
                 console.log(event);
                 if (event.data != "{}") {
                     const newData = JSON.parse(event.data);
+
+                    if (typeof newData.vedirect !== 'undefined') { Object.assign(this.liveData.vedirect, newData.vedirect); }
+                    if (typeof newData.huawei !== 'undefined') { Object.assign(this.liveData.huawei, newData.huawei); }
+                    if (typeof newData.battery !== 'undefined') { Object.assign(this.liveData.battery, newData.battery); }
+                    if (typeof newData.power_meter !== 'undefined') { Object.assign(this.liveData.power_meter, newData.power_meter); }
+
+                    if (typeof newData.total === 'undefined') { return; }
+
                     Object.assign(this.liveData.total, newData.total);
                     Object.assign(this.liveData.hints, newData.hints);
-                    Object.assign(this.liveData.vedirect, newData.vedirect);
-                    Object.assign(this.liveData.huawei, newData.huawei);
-                    Object.assign(this.liveData.battery, newData.battery);
-                    Object.assign(this.liveData.power_meter, newData.power_meter);
 
                     const foundIdx = this.liveData.inverters.findIndex((element) => element.serial == newData.inverters[0].serial);
                     if (foundIdx == -1) {


### PR DESCRIPTION
the update frequency of Victron MPPT charger data, the battery SoC, the huawei charger power, and the power meter differ from one another, and differ in particular from the inverter update frequency.

the OnBattery-specific data is now handled in a new method, outside the upstream code, which merely calls the new function(s). the new function will update the websocket independently from inverter updates. also, it adds the respective data if it actually changed since it was last updated through the websocket.

for the webapp to be able to recover in case of errors, all values are also written to the websocket with a fixed interval of 10 seconds.

in particular, this allows to observe power meter readings update while the inverters are being fetched. for me this makes a big difference as the power meter is reporting with 1Hz, while the inverter polling is much less frequent.