### PR TITLE
fix: prevent getTotalPower() reading intermediate results

### DIFF
--- a/include/PowerMeter.h
+++ b/include/PowerMeter.h
@@ -6,6 +6,7 @@
 #include <Arduino.h>
 #include <map>
 #include <list>
+#include <mutex>
 #include "SDM.h"
 #include "sml.h"
 #include <TaskSchedulerDeclarations.h>
@@ -65,6 +66,8 @@ private:
     float _powerMeterExport = 0.0;
 
     std::map<String, float*> _mqttSubscriptions;
+
+    mutable std::mutex _mutex;
 
     void readPowerMeter();
 


### PR DESCRIPTION
the SDM power meter (among others) writes the power consumption of three phases in multiple steps. this change helps to prevent getTotalPower() reading intermediate values, i.e., reading a new value for phase 1 but old values for phase 2 and 3 since phase 2 is currently read.

cache the values, and write them all at once, protected by a mutex, later.

closes #732.