### PR TITLE
add new Victron SmartShunt values to liveView and MQTT (HASS)

### DIFF
--- a/include/BatteryStats.h
+++ b/include/BatteryStats.h
@@ -152,6 +152,9 @@ class VictronSmartShuntStats : public BatteryStats {
         float _chargedEnergy;
         float _dischargedEnergy;
         String _modelName;
+        int32_t _instantaneousPower;
+        float _consumedAmpHours;
+        int32_t _lastFullCharge;
 
         bool _alarmLowVoltage;
         bool _alarmHighVoltage;

--- a/src/BatteryStats.cpp
+++ b/src/BatteryStats.cpp
@@ -384,7 +384,9 @@ void VictronSmartShuntStats::updateFrom(VeDirectShuntController::veShuntStruct c
     _manufacturer = "Victron " + _modelName;
     _temperature = shuntData.T;
     _tempPresent = shuntData.tempPresent;
-
+    _instantaneousPower = shuntData.P;
+    _consumedAmpHours = static_cast<float>(shuntData.CE) / 1000;
+    _lastFullCharge = shuntData.H9 / 60;
     // shuntData.AR is a bitfield, so we need to check each bit individually
     _alarmLowVoltage = shuntData.AR & 1;
     _alarmHighVoltage = shuntData.AR & 2;
@@ -403,6 +405,9 @@ void VictronSmartShuntStats::getLiveViewData(JsonVariant& root) const {
     addLiveViewValue(root, "chargeCycles", _chargeCycles, "", 0);
     addLiveViewValue(root, "chargedEnergy", _chargedEnergy, "kWh", 2);
     addLiveViewValue(root, "dischargedEnergy", _dischargedEnergy, "kWh", 2);
+    addLiveViewValue(root, "instantaneousPower", _instantaneousPower, "W", 0);
+    addLiveViewValue(root, "consumedAmpHours", _consumedAmpHours, "Ah", 3);
+    addLiveViewValue(root, "lastFullCharge", _lastFullCharge, "min", 0);
     if (_tempPresent) {
         addLiveViewValue(root, "temperature", _temperature, "°C", 0);
     }
@@ -421,4 +426,7 @@ void VictronSmartShuntStats::mqttPublish() const {
     MqttSettings.publish(F("battery/chargeCycles"), String(_chargeCycles));
     MqttSettings.publish(F("battery/chargedEnergy"), String(_chargedEnergy));
     MqttSettings.publish(F("battery/dischargedEnergy"), String(_dischargedEnergy));
+    MqttSettings.publish(F("battery/instantaneousPower"), String(_instantaneousPower));
+    MqttSettings.publish(F("battery/consumedAmpHours"), String(_consumedAmpHours));
+    MqttSettings.publish(F("battery/lastFullCharge"), String(_lastFullCharge));
 }

--- a/src/MqttHandleBatteryHass.cpp
+++ b/src/MqttHandleBatteryHass.cpp
@@ -111,6 +111,14 @@ void MqttHandleBatteryHassClass::loop()
         case 2: // SoC from MQTT
             break;
         case 3: // Victron SmartShunt
+            publishSensor("Voltage", "mdi:battery-charging", "voltage", "voltage", "measurement", "V");
+            publishSensor("Current", "mdi:current-dc", "current", "current", "measurement", "A");
+            publishSensor("Instantaneous Power", NULL, "instantaneousPower", "power", "measurement", "W");
+            publishSensor("Charged Energy", NULL, "chargedEnergy", "energy", "total_increasing", "kWh");
+            publishSensor("Discharged Energy", NULL, "dischargedEnergy", "energy", "total_increasing", "kWh");
+            publishSensor("Charge Cycles", "mdi:counter", "chargeCycles");
+            publishSensor("Consumed Amp Hours", NULL, "consumedAmpHours", NULL, "measurement", "Ah");
+            publishSensor("Last Full Charge", "mdi:timelapse", "lastFullCharge", NULL, NULL, "min");
             break;
     }
 

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -817,7 +817,7 @@
         "Close": "Schließen",
         "SetVoltageLimit": "Spannungslimit:",
         "SetCurrentLimit": "Stromlimit:",
-        "CurrentLimit": "Aktuelles Limit: "  
+        "CurrentLimit": "Aktuelles Limit: "
       },
       "acchargeradmin": {
         "ChargerSettings": "AC Ladegerät Einstellungen",
@@ -900,6 +900,9 @@
         "bmsInternal": "BMS intern",
         "chargeCycles": "Ladezyklen",
         "chargedEnergy": "Geladene Energie",
-        "dischargedEnergy": "Entladene Energie"
+        "dischargedEnergy": "Entladene Energie",
+        "instantaneousPower": "Aktuelle Leistung",
+        "consumedAmpHours": "Verbrauche Amperestunden",
+        "lastFullCharge": "Letztes mal Vollgeladen"
       }
 }

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -824,7 +824,7 @@
         "Close": "close",
         "SetVoltageLimit": "Voltage limit:",
         "SetCurrentLimit": "Current limit:",
-        "CurrentLimit": "Current limit:"  
+        "CurrentLimit": "Current limit:"
       },
       "acchargeradmin": {
         "ChargerSettings": "AC Charger Settings",
@@ -907,6 +907,9 @@
         "bmsInternal": "BMS internal",
         "chargeCycles": "Charge cycles",
         "chargedEnergy": "Charged energy",
-        "dischargedEnergy": "Discharged energy"
+        "dischargedEnergy": "Discharged energy",
+        "instantaneousPower": "Instantaneous Power",
+        "consumedAmpHours": "Consumed Amp Hours",
+        "lastFullCharge": "Last full Charge"
       }
 }

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -816,7 +816,7 @@
         "Close": "close",
         "SetVoltageLimit": "Voltage limit:",
         "SetCurrentLimit": "Current limit:",
-        "CurrentLimit": "Current limit:"  
+        "CurrentLimit": "Current limit:"
       },
       "acchargeradmin": {
         "ChargerSettings": "AC Charger Settings",
@@ -899,6 +899,9 @@
         "bmsInternal": "BMS internal",
         "chargeCycles": "Charge cycles",
         "chargedEnergy": "Charged energy",
-        "dischargedEnergy": "Discharged energy"
+        "dischargedEnergy": "Discharged energy",
+        "instantaneousPower": "Instantaneous Power",
+        "consumedAmpHours": "Consumed Amp Hours",
+        "lastFullCharge": "Last full Charge"
       }
 }


### PR DESCRIPTION
Da bisher keine "eigenen" Victron SmartShunt Werte nach HA per Autodiscovery verfügbar gemacht werden habe ich dort nun ein paar Werte veröffentlicht. 
Desweiteren habe ich zum LiveView die Aktuelle Leistung, Verbrauchten Amperestunden und die Letzte volle Ladung hinzugefügt.
Man könnte sich nun überlegen das noch in Kategorien sinnvoll zu unterteilen, aber fürs erste war das für mich so in Ordnung. 
Bei der Benahmung bin ich noch für eventuell bessere Vorschläge offen :D 

<img width="873" alt="image" src="https://github.com/helgeerbe/OpenDTU-OnBattery/assets/122352327/ad3b04c3-0fd3-47d3-9c28-c3a8f9c71b45">
<img width="327" alt="image" src="https://github.com/helgeerbe/OpenDTU-OnBattery/assets/122352327/e0ea0d49-4ae2-4356-9acd-bcaaa8fc2d09">
