### PR TITLE
Huawei AC-Charger (Pylontech) BMS connection 

### DIFF
--- a/include/BatteryStats.h
+++ b/include/BatteryStats.h
@@ -7,6 +7,7 @@
 #include "Arduino.h"
 #include "JkBmsDataPoints.h"
 #include "VeDirectShuntController.h"
+#include <cfloat>
 
 // mandatory interface for all kinds of batteries
 class BatteryStats {
@@ -37,7 +38,10 @@ class BatteryStats {
 
         // returns true if the battery reached a critically low voltage/SoC,
         // such that it is in need of charging to prevent degredation.
-        virtual bool needsCharging() const { return false; }
+        virtual bool getImmediateChargingRequest() const { return false; };
+
+        virtual float getChargeCurrent() const { return 0; };
+        virtual float getChargeCurrentLimitation() const { return FLT_MAX; };
 
     protected:
         virtual void mqttPublish() const;
@@ -71,7 +75,9 @@ class PylontechBatteryStats : public BatteryStats {
     public:
         void getLiveViewData(JsonVariant& root) const final;
         void mqttPublish() const final;
-        bool needsCharging() const final { return _chargeImmediately; }
+        bool getImmediateChargingRequest() const { return _chargeImmediately; } ;
+        float getChargeCurrent() const { return _current; } ;
+        float getChargeCurrentLimitation() const { return _chargeCurrentLimitation; } ;
 
     private:
         void setManufacturer(String&& m) { _manufacturer = std::move(m); }

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -240,6 +240,7 @@ struct CONFIG_T {
         bool Enabled;
         uint32_t CAN_Controller_Frequency;
         bool Auto_Power_Enabled;
+        bool Emergency_Charge_Enabled;
         float Auto_Power_Voltage_Limit;
         float Auto_Power_Enable_Voltage_Limit;
         float Auto_Power_Lower_Power_Limit;

--- a/include/Huawei_can.h
+++ b/include/Huawei_can.h
@@ -150,6 +150,7 @@ private:
 
     uint8_t _autoPowerEnabledCounter = 0;
     bool _autoPowerEnabled = false;
+    bool _batteryEmergencyCharging = false;
 };
 
 extern HuaweiCanClass HuaweiCan;

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -216,6 +216,7 @@ bool ConfigurationClass::write()
     huawei["enabled"] = config.Huawei.Enabled;
     huawei["can_controller_frequency"] = config.Huawei.CAN_Controller_Frequency;
     huawei["auto_power_enabled"] = config.Huawei.Auto_Power_Enabled;
+    huawei["emergency_charge_enabled"] = config.Huawei.Emergency_Charge_Enabled;
     huawei["voltage_limit"] = config.Huawei.Auto_Power_Voltage_Limit;
     huawei["enable_voltage_limit"] = config.Huawei.Auto_Power_Enable_Voltage_Limit;
     huawei["lower_power_limit"] = config.Huawei.Auto_Power_Lower_Power_Limit;
@@ -464,6 +465,7 @@ bool ConfigurationClass::read()
     config.Huawei.Enabled = huawei["enabled"] | HUAWEI_ENABLED;
     config.Huawei.CAN_Controller_Frequency = huawei["can_controller_frequency"] | HUAWEI_CAN_CONTROLLER_FREQUENCY;
     config.Huawei.Auto_Power_Enabled = huawei["auto_power_enabled"] | false;
+    config.Huawei.Emergency_Charge_Enabled = huawei["emergency_charge_enabled"] | false;
     config.Huawei.Auto_Power_Voltage_Limit = huawei["voltage_limit"] | HUAWEI_AUTO_POWER_VOLTAGE_LIMIT;
     config.Huawei.Auto_Power_Enable_Voltage_Limit =  huawei["enable_voltage_limit"] | HUAWEI_AUTO_POWER_ENABLE_VOLTAGE_LIMIT;
     config.Huawei.Auto_Power_Lower_Power_Limit = huawei["lower_power_limit"] | HUAWEI_AUTO_POWER_LOWER_POWER_LIMIT;

--- a/src/WebApi_Huawei.cpp
+++ b/src/WebApi_Huawei.cpp
@@ -188,6 +188,7 @@ void WebApiHuaweiClass::onAdminGet(AsyncWebServerRequest* request)
     root["enabled"] = config.Huawei.Enabled;
     root["can_controller_frequency"] = config.Huawei.CAN_Controller_Frequency;
     root["auto_power_enabled"] = config.Huawei.Auto_Power_Enabled;
+    root["emergency_charge_enabled"] = config.Huawei.Emergency_Charge_Enabled;
     root["voltage_limit"] = static_cast<int>(config.Huawei.Auto_Power_Voltage_Limit * 100) / 100.0;
     root["enable_voltage_limit"] = static_cast<int>(config.Huawei.Auto_Power_Enable_Voltage_Limit * 100) / 100.0;
     root["lower_power_limit"] = config.Huawei.Auto_Power_Lower_Power_Limit;
@@ -239,6 +240,7 @@ void WebApiHuaweiClass::onAdminPost(AsyncWebServerRequest* request)
     if (!(root.containsKey("enabled")) ||
         !(root.containsKey("can_controller_frequency")) ||
         !(root.containsKey("auto_power_enabled")) ||
+        !(root.containsKey("emergency_charge_enabled")) ||
         !(root.containsKey("voltage_limit")) ||
         !(root.containsKey("lower_power_limit")) ||
         !(root.containsKey("upper_power_limit"))) {
@@ -253,11 +255,11 @@ void WebApiHuaweiClass::onAdminPost(AsyncWebServerRequest* request)
     config.Huawei.Enabled = root["enabled"].as<bool>();
     config.Huawei.CAN_Controller_Frequency = root["can_controller_frequency"].as<uint32_t>();
     config.Huawei.Auto_Power_Enabled = root["auto_power_enabled"].as<bool>();
+    config.Huawei.Emergency_Charge_Enabled = root["emergency_charge_enabled"].as<bool>();
     config.Huawei.Auto_Power_Voltage_Limit = root["voltage_limit"].as<float>();
     config.Huawei.Auto_Power_Enable_Voltage_Limit = root["enable_voltage_limit"].as<float>();
     config.Huawei.Auto_Power_Lower_Power_Limit = root["lower_power_limit"].as<float>();
     config.Huawei.Auto_Power_Upper_Power_Limit = root["upper_power_limit"].as<float>();    
-   
     WebApi.writeConfig(retMsg);
 
     response->setLength();

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -836,10 +836,13 @@
         "Limits": "Limits",
         "VoltageLimit": "Ladespannungslimit",
         "enableVoltageLimit": "Start Spannungslimit",
+        "stopVoltageLimitHint": "Maximal Spannung des Ladegeräts. Entspricht der geünschten Ladeschlussspannung der Batterie. Verwendet für die Automatische Leistungssteuerung und beim Notfallladen",
         "enableVoltageLimitHint": "Die automatische Leistungssteuerung wird deaktiviert wenn die Ausgangsspannung über diesem Wert liegt und wenn gleichzeitig die Ausgangsleistung unter die minimale Leistung fällt.\nDie automatische Leistungssteuerung wird re-aktiveiert wenn die Batteriespannung unter diesen Wert fällt.",
+        "maxPowerLimitHint": "Maximale Ausgangsleistung. Verwendet für die Automatische Leistungssteuerung und beim Notfallladen",
         "lowerPowerLimit": "Minimale Leistung",
         "upperPowerLimit": "Maximale Leistung",
-        "Seconds": "@:base.Seconds"
+        "Seconds": "@:base.Seconds",
+        "EnableEmergencyCharge": "Notfallladen: Batterie wird mit maximaler Leistung geladen wenn durch das Batterie BMS angefordert"
     },
     "battery": {
         "battery": "Batterie",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -843,10 +843,13 @@
         "Limits": "Limits",
         "VoltageLimit": "Charge Voltage limit",
         "enableVoltageLimit": "Re-enable voltage limit",
+        "stopVoltageLimitHint": "Maximum charger voltage. Equals battery charge voltage limit. Used for automatic power control and when emergency charging",
         "enableVoltageLimitHint": "Automatic power control is disabled if the output voltage is higher then this value and if the output power drops below the minimum output power limit (set below).\nAutomatic power control is re-enabled if the battery voltage drops below the value set in this field.",
+        "maxPowerLimitHint": "Maximum output power. Used for automatic power control and when emergency charging",
         "lowerPowerLimit": "Minimum output power",
         "upperPowerLimit": "Maximum output power",
-        "Seconds": "@:base.Seconds"
+        "Seconds": "@:base.Seconds",
+        "EnableEmergencyCharge": "Emergency charge. Battery charged with maximum power if requested by Battery BMS"
     },
     "battery": {
         "battery": "Battery",

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -834,10 +834,13 @@
         "Limits": "Limits",
         "VoltageLimit": "Charge Voltage limit",
         "enableVoltageLimit": "Re-enable voltage limit",
+        "stopVoltageLimitHint": "Maximum charger voltage. Equals battery charge voltage limit. Used for automatic power control and when emergency charging",
         "enableVoltageLimitHint": "Automatic power control is disabled if the output voltage is higher then this value and if the output power drops below the minimum output power limit (set below).\nAutomatic power control is re-enabled if the battery voltage drops below the value set in this field.",
+        "maxPowerLimitHint": "Maximum output power. Used for automatic power control and when emergency charging",
         "lowerPowerLimit": "Minimum output power",
         "upperPowerLimit": "Maximum output power",
-        "Seconds": "@:base.Seconds"
+        "Seconds": "@:base.Seconds",
+        "EnableEmergencyCharge": "Emergency charge. Battery charged with maximum power if requested by Battery BMS"
     },
     "battery": {
         "battery": "Battery",

--- a/webapp/src/types/AcChargerConfig.ts
+++ b/webapp/src/types/AcChargerConfig.ts
@@ -6,4 +6,5 @@ export interface AcChargerConfig {
   enable_voltage_limit: number;
   lower_power_limit: number;
   upper_power_limit: number;
+  emergency_charge_enabled: boolean;
 }

--- a/webapp/src/views/AcChargerAdminView.vue
+++ b/webapp/src/views/AcChargerAdminView.vue
@@ -28,10 +28,17 @@
                               v-model="acChargerConfigList.auto_power_enabled"
                               type="checkbox" wide/>
 
+                <InputElement v-show="acChargerConfigList.enabled"
+                              :label="$t('acchargeradmin.EnableEmergencyCharge')"
+                              v-model="acChargerConfigList.emergency_charge_enabled"
+                              type="checkbox" wide/>
+
                 <CardElement :text="$t('acchargeradmin.Limits')" textVariant="text-bg-primary" add-space
-                              v-show="acChargerConfigList.auto_power_enabled">
+                              v-show="acChargerConfigList.auto_power_enabled || acChargerConfigList.emergency_charge_enabled">
                     <div class="row mb-3">
-                        <label for="voltageLimit" class="col-sm-2 col-form-label">{{ $t('acchargeradmin.VoltageLimit') }}:</label>
+                        <label for="voltageLimit" class="col-sm-2 col-form-label">{{ $t('acchargeradmin.VoltageLimit') }}:
+                          <BIconInfoCircle v-tooltip :title="$t('acchargeradmin.stopVoltageLimitHint')" />
+                        </label>
                         <div class="col-sm-10">
                             <div class="input-group">
                                 <input type="number" step="0.01" class="form-control" id="voltageLimit"
@@ -60,7 +67,9 @@
                                     <span class="input-group-text" id="lowerPowerLimitDescription">W</span>
                             </div>
                         </div>
-                        <label for="upperPowerLimit" class="col-sm-2 col-form-label">{{ $t('acchargeradmin.upperPowerLimit') }}:</label>
+                        <label for="upperPowerLimit" class="col-sm-2 col-form-label">{{ $t('acchargeradmin.upperPowerLimit') }}:
+                          <BIconInfoCircle v-tooltip :title="$t('acchargeradmin.maxPowerLimitHint')" />
+                        </label>
                         <div class="col-sm-10">
                             <div class="input-group">
                                 <input type="number" class="form-control" id="upperPowerLimit"


### PR DESCRIPTION
This PR connects the Huawei AC-Charger with the Battery BMS. It specifically introduces the following features:

When the BMS issues an charge immediate request and the charger is in internal automatic control mode then charging is started with full configured power. This behavior enabled / disabled on the GUI

The Huawei charger will respect BMS current limits now when charging and limit the current taking the BMS limit and an estimate of other DC sources into account.

I did some testing but would like to monitor this a bit over the course of the coming days. Marking this PR as draft for now.

The request is in https://github.com/helgeerbe/OpenDTU-OnBattery/issues/723