### PR TITLE
Feature: implement PowerMeter pin config for serial interfaces

### DIFF
--- a/include/PinMapping.h
+++ b/include/PinMapping.h
@@ -38,6 +38,9 @@ struct PinMapping_t {
     uint8_t display_clk;
     uint8_t display_cs;
     uint8_t display_reset;
+    int8_t led[PINMAPPING_LED_COUNT];
+
+    // OpenDTU-OnBattery-specific pins below
     int8_t victron_tx;
     int8_t victron_rx;
     int8_t victron_tx2;
@@ -52,7 +55,9 @@ struct PinMapping_t {
     int8_t huawei_irq;
     int8_t huawei_cs;
     int8_t huawei_power;
-    int8_t led[PINMAPPING_LED_COUNT];
+    int8_t powermeter_rx;
+    int8_t powermeter_tx;
+    int8_t powermeter_dere;
 };
 
 class PinMappingClass {

--- a/include/PowerMeter.h
+++ b/include/PowerMeter.h
@@ -10,18 +10,7 @@
 #include "SDM.h"
 #include "sml.h"
 #include <TaskSchedulerDeclarations.h>
-
-#ifndef SDM_RX_PIN
-#define SDM_RX_PIN 13
-#endif
-
-#ifndef SDM_TX_PIN
-#define SDM_TX_PIN 32
-#endif
-
-#ifndef SML_RX_PIN
-#define SML_RX_PIN 35
-#endif
+#include <SoftwareSerial.h>
 
 typedef struct {
   const unsigned char OBIS[6];
@@ -31,13 +20,13 @@ typedef struct {
 
 class PowerMeterClass {
 public:
-    enum SOURCE {
-        SOURCE_MQTT = 0,
-        SOURCE_SDM1PH = 1,
-        SOURCE_SDM3PH = 2,
-        SOURCE_HTTP = 3,
-        SOURCE_SML = 4,
-        SOURCE_SMAHM2 = 5
+    enum class Source : unsigned {
+        MQTT = 0,
+        SDM1PH = 1,
+        SDM3PH = 2,
+        HTTP = 3,
+        SML = 4,
+        SMAHM2 = 5
     };
     void init(Scheduler& scheduler);
     float getPowerTotal(bool forceUpdate = true);
@@ -50,7 +39,7 @@ private:
     void onMqttMessage(const espMqttClientTypes::MessageProperties& properties,
         const char* topic, const uint8_t* payload, size_t len, size_t index, size_t total);
 
-     Task _loopTask;
+    Task _loopTask;
 
     bool _verboseLogging = true;
     uint32_t _lastPowerMeterCheck;
@@ -69,6 +58,9 @@ private:
     std::map<String, float*> _mqttSubscriptions;
 
     mutable std::mutex _mutex;
+
+    std::unique_ptr<SDM> _upSdm = nullptr;
+    std::unique_ptr<SoftwareSerial> _upSmlSerial = nullptr;
 
     void readPowerMeter();
 

--- a/src/PinMapping.cpp
+++ b/src/PinMapping.cpp
@@ -144,6 +144,18 @@
 #define HUAWEI_PIN_POWER -1
 #endif
 
+#ifndef POWERMETER_PIN_RX
+#define POWERMETER_PIN_RX -1
+#endif
+
+#ifndef POWERMETER_PIN_TX
+#define POWERMETER_PIN_TX -1
+#endif
+
+#ifndef POWERMETER_PIN_DERE
+#define POWERMETER_PIN_DERE -1
+#endif
+
 PinMappingClass PinMapping;
 
 PinMappingClass::PinMappingClass()
@@ -182,6 +194,10 @@ PinMappingClass::PinMappingClass()
     _pinMapping.display_cs = DISPLAY_CS;
     _pinMapping.display_reset = DISPLAY_RESET;
 
+    _pinMapping.led[0] = LED0;
+    _pinMapping.led[1] = LED1;
+
+    // OpenDTU-OnBattery-specific pins below
     _pinMapping.victron_rx = VICTRON_PIN_RX;
     _pinMapping.victron_tx = VICTRON_PIN_TX;
 
@@ -199,8 +215,10 @@ PinMappingClass::PinMappingClass()
     _pinMapping.huawei_cs = HUAWEI_PIN_CS;
     _pinMapping.huawei_irq = HUAWEI_PIN_IRQ;
     _pinMapping.huawei_power = HUAWEI_PIN_POWER;
-    _pinMapping.led[0] = LED0;
-    _pinMapping.led[1] = LED1;
+
+    _pinMapping.powermeter_rx = POWERMETER_PIN_RX;
+    _pinMapping.powermeter_tx = POWERMETER_PIN_TX;
+    _pinMapping.powermeter_dere = POWERMETER_PIN_DERE;
 }
 
 PinMapping_t& PinMappingClass::get()
@@ -260,6 +278,10 @@ bool PinMappingClass::init(const String& deviceMapping)
             _pinMapping.display_cs = doc[i]["display"]["cs"] | DISPLAY_CS;
             _pinMapping.display_reset = doc[i]["display"]["reset"] | DISPLAY_RESET;
 
+            _pinMapping.led[0] = doc[i]["led"]["led0"] | LED0;
+            _pinMapping.led[1] = doc[i]["led"]["led1"] | LED1;
+
+            // OpenDTU-OnBattery-specific pins below
             _pinMapping.victron_rx = doc[i]["victron"]["rx"] | VICTRON_PIN_RX;
             _pinMapping.victron_tx = doc[i]["victron"]["tx"] | VICTRON_PIN_TX;
             _pinMapping.victron_rx2 = doc[i]["victron"]["rx2"] | VICTRON_PIN_RX;
@@ -277,8 +299,9 @@ bool PinMappingClass::init(const String& deviceMapping)
             _pinMapping.huawei_cs = doc[i]["huawei"]["cs"] | HUAWEI_PIN_CS;
             _pinMapping.huawei_power = doc[i]["huawei"]["power"] | HUAWEI_PIN_POWER;
 
-            _pinMapping.led[0] = doc[i]["led"]["led0"] | LED0;
-            _pinMapping.led[1] = doc[i]["led"]["led1"] | LED1;
+            _pinMapping.powermeter_rx = doc[i]["powermeter"]["rx"] | POWERMETER_PIN_RX;
+            _pinMapping.powermeter_tx = doc[i]["powermeter"]["tx"] | POWERMETER_PIN_TX;
+            _pinMapping.powermeter_dere = doc[i]["powermeter"]["dere"] | POWERMETER_PIN_DERE;
 
             return true;
         }

--- a/src/WebApi_powermeter.cpp
+++ b/src/WebApi_powermeter.cpp
@@ -118,7 +118,7 @@ void WebApiPowerMeterClass::onAdminPost(AsyncWebServerRequest* request)
         return;
     }
 
-    if (root["source"].as<uint8_t>() == PowerMeter.SOURCE_HTTP) {
+    if (static_cast<PowerMeterClass::Source>(root["source"].as<uint8_t>()) == PowerMeterClass::Source::HTTP) {
         JsonArray http_phases = root["http_phases"];
         for (uint8_t i = 0; i < http_phases.size(); i++) {
             JsonObject phase = http_phases[i].as<JsonObject>();


### PR DESCRIPTION
in your pin_mapping.json, add a powermeter object like this:

```
[
    {
        "name": "My Board",
        ...
        "powermeter": {
            "rx": <num>,
            "tx": <num>,
            "dere": <num>
        },
        ...
    }
]
```

the SML power meter requires the rx pin to be set. the SDM power meter requires the rx and tx pins are set. the "dere" pin pin is optional and if set, this pin controls the driver enable and receiver enable pins of the RS485 transceiver. the SDM library handles this pin.

closes #771.