### PR TITLE
workflow: ignore v** tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - master
       - development
     tags-ignore:        
-      - v*
+      - 'v**'
   pull_request:
     paths-ignore:
       - docs/**


### PR DESCRIPTION
this is an attempt to exempt the whole build workflow (and respective releases from being created) for upstream tags.

inspired by https://github.com/orgs/community/discussions/25615.