### PR TITLE
Fix Victron yield precision

### DIFF
--- a/src/WebApi_ws_vedirect_live.cpp
+++ b/src/WebApi_ws_vedirect_live.cpp
@@ -196,13 +196,13 @@ void WebApiWsVedirectLiveClass::populateJson(const JsonObject &root, const VeDir
     input["IPV"]["d"] = 2;
     input["YieldToday"]["v"] = mpptData.yieldToday_H20_Wh / 1000.0;
     input["YieldToday"]["u"] = "kWh";
-    input["YieldToday"]["d"] = 3;
+    input["YieldToday"]["d"] = 2;
     input["YieldYesterday"]["v"] = mpptData.yieldYesterday_H22_Wh / 1000.0;
     input["YieldYesterday"]["u"] = "kWh";
-    input["YieldYesterday"]["d"] = 3;
+    input["YieldYesterday"]["d"] = 2;
     input["YieldTotal"]["v"] = mpptData.yieldTotal_H19_Wh / 1000.0;
     input["YieldTotal"]["u"] = "kWh";
-    input["YieldTotal"]["d"] = 3;
+    input["YieldTotal"]["d"] = 2;
     input["MaximumPowerToday"]["v"] = mpptData.maxPowerToday_H21_W;
     input["MaximumPowerToday"]["u"] = "W";
     input["MaximumPowerToday"]["d"] = 0;


### PR DESCRIPTION
The precision of Victron's yield displayed on the WebView is too high. For my Victron MPPT 100/20, it shows only a 10 Wh precision. I believe this precision is not dependent on the MPPT being used. 
So now only 2 decimals are shown. 