### PR TITLE
Fix AC charger power in live view

### DIFF
--- a/src/WebApi_ws_live.cpp
+++ b/src/WebApi_ws_live.cpp
@@ -80,7 +80,7 @@ void WebApiWsLiveClass::generateOnBatteryJsonResponse(JsonVariant& root, bool al
 
         if (config.Huawei.Enabled) {
             const RectifierParameters_t * rp = HuaweiCan.get();
-            addTotalField(huaweiObj, "Power", rp->output_power, "W", 2);
+            addTotalField(huaweiObj, "Power", rp->input_power, "W", 2);
         }
 
         if (!all) { _lastPublishHuawei = millis(); }


### PR DESCRIPTION
makes the value match its description. since most values in the top part of the live view are related to the AC side of the system, it makes sense to use the correct value rather than to change the description.

closes #846.