### PR TITLE
Feature: HTTP power meter: mW/kW as unit and sign inversion

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -64,6 +64,7 @@ struct INVERTER_CONFIG_T {
 
 struct POWERMETER_HTTP_PHASE_CONFIG_T {
     enum Auth { None, Basic, Digest };
+    enum Unit { Watts = 0, MilliWatts = 1, KiloWatts = 2 };
     bool Enabled;
     char Url[POWERMETER_MAX_HTTP_URL_STRLEN + 1];
     Auth AuthType;
@@ -73,6 +74,7 @@ struct POWERMETER_HTTP_PHASE_CONFIG_T {
     char HeaderValue[POWERMETER_MAX_HTTP_HEADER_VALUE_STRLEN + 1];
     uint16_t Timeout;
     char JsonPath[POWERMETER_MAX_HTTP_JSON_PATH_STRLEN + 1];
+    Unit PowerUnit;
 };
 using PowerMeterHttpConfig = struct POWERMETER_HTTP_PHASE_CONFIG_T;
 

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -62,8 +62,8 @@ struct INVERTER_CONFIG_T {
     CHANNEL_CONFIG_T channel[INV_MAX_CHAN_COUNT];
 };
 
-enum Auth { none, basic, digest };
 struct POWERMETER_HTTP_PHASE_CONFIG_T {
+    enum Auth { None, Basic, Digest };
     bool Enabled;
     char Url[POWERMETER_MAX_HTTP_URL_STRLEN + 1];
     Auth AuthType;
@@ -74,6 +74,7 @@ struct POWERMETER_HTTP_PHASE_CONFIG_T {
     uint16_t Timeout;
     char JsonPath[POWERMETER_MAX_HTTP_JSON_PATH_STRLEN + 1];
 };
+using PowerMeterHttpConfig = struct POWERMETER_HTTP_PHASE_CONFIG_T;
 
 struct CONFIG_T {
     struct {
@@ -196,7 +197,7 @@ struct CONFIG_T {
         uint32_t SdmAddress;
         uint32_t HttpInterval;
         bool HttpIndividualRequests;
-        POWERMETER_HTTP_PHASE_CONFIG_T Http_Phase[POWERMETER_MAX_PHASES];
+        PowerMeterHttpConfig Http_Phase[POWERMETER_MAX_PHASES];
     } PowerMeter;
 
     struct {

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -75,6 +75,7 @@ struct POWERMETER_HTTP_PHASE_CONFIG_T {
     uint16_t Timeout;
     char JsonPath[POWERMETER_MAX_HTTP_JSON_PATH_STRLEN + 1];
     Unit PowerUnit;
+    bool SignInverted;
 };
 using PowerMeterHttpConfig = struct POWERMETER_HTTP_PHASE_CONFIG_T;
 

--- a/include/HttpPowerMeter.h
+++ b/include/HttpPowerMeter.h
@@ -26,7 +26,7 @@ private:
     String extractParam(String& authReq, const String& param, const char delimit);
     String getcNonce(const int len);
     String getDigestAuth(String& authReq, const String& username, const String& password, const String& method, const String& uri, unsigned int counter);
-    bool tryGetFloatValueForPhase(int phase, const char* jsonPath, Unit_t unit);
+    bool tryGetFloatValueForPhase(int phase, const char* jsonPath, Unit_t unit, bool signInverted);
     void prepareRequest(uint32_t timeout, const char* httpHeader, const char* httpValue);
     String sha256(const String& data);
 };

--- a/include/HttpPowerMeter.h
+++ b/include/HttpPowerMeter.h
@@ -7,6 +7,7 @@
 #include "Configuration.h"
 
 using Auth_t = PowerMeterHttpConfig::Auth;
+using Unit_t = PowerMeterHttpConfig::Unit;
 
 class HttpPowerMeterClass {
 public:
@@ -25,7 +26,7 @@ private:
     String extractParam(String& authReq, const String& param, const char delimit);
     String getcNonce(const int len);
     String getDigestAuth(String& authReq, const String& username, const String& password, const String& method, const String& uri, unsigned int counter);
-    bool tryGetFloatValueForPhase(int phase, const char* jsonPath);
+    bool tryGetFloatValueForPhase(int phase, const char* jsonPath, Unit_t unit);
     void prepareRequest(uint32_t timeout, const char* httpHeader, const char* httpValue);
     String sha256(const String& data);
 };

--- a/include/HttpPowerMeter.h
+++ b/include/HttpPowerMeter.h
@@ -4,6 +4,9 @@
 #include <stdint.h>
 #include <Arduino.h>
 #include <HTTPClient.h>
+#include "Configuration.h"
+
+using Auth_t = PowerMeterHttpConfig::Auth;
 
 class HttpPowerMeterClass {
 public:
@@ -11,23 +14,20 @@ public:
     bool updateValues();
     float getPower(int8_t phase);
     char httpPowerMeterError[256];
-    bool queryPhase(int phase, const String& url, Auth authType, const char* username, const char* password, 
-        const char* httpHeader, const char* httpValue, uint32_t timeout, const char* jsonPath);
+    bool queryPhase(int phase, PowerMeterHttpConfig const& config);
 
-
-private:    
+private:
     float power[POWERMETER_MAX_PHASES];
     HTTPClient httpClient;
     String httpResponse;
-    bool httpRequest(int phase, WiFiClient &wifiClient, const String& host, uint16_t port, const String& uri, bool https, Auth authType, const char* username,
-           const char* password, const char* httpHeader, const char* httpValue, uint32_t timeout, const char* jsonPath);
+    bool httpRequest(int phase, WiFiClient &wifiClient, const String& host, uint16_t port, const String& uri, bool https, PowerMeterHttpConfig const& config);
     bool extractUrlComponents(String url, String& _protocol, String& _hostname, String& _uri, uint16_t& uint16_t, String& _base64Authorization);
     String extractParam(String& authReq, const String& param, const char delimit);
     String getcNonce(const int len);
     String getDigestAuth(String& authReq, const String& username, const String& password, const String& method, const String& uri, unsigned int counter);
     bool tryGetFloatValueForPhase(int phase, const char* jsonPath);
-    void prepareRequest(uint32_t timeout, const char* httpHeader, const char* httpValue);    
-    String sha256(const String& data);    
+    void prepareRequest(uint32_t timeout, const char* httpHeader, const char* httpValue);
+    String sha256(const String& data);
 };
 
 extern HttpPowerMeterClass HttpPowerMeter;

--- a/include/WebApi_powermeter.h
+++ b/include/WebApi_powermeter.h
@@ -3,7 +3,8 @@
 
 #include <ESPAsyncWebServer.h>
 #include <TaskSchedulerDeclarations.h>
-
+#include <ArduinoJson.h>
+#include "Configuration.h"
 
 class WebApiPowerMeterClass {
 public:
@@ -13,6 +14,7 @@ private:
     void onStatus(AsyncWebServerRequest* request);
     void onAdminGet(AsyncWebServerRequest* request);
     void onAdminPost(AsyncWebServerRequest* request);
+    void decodeJsonPhaseConfig(JsonObject const& json, PowerMeterHttpConfig& config) const;
     void onTestHttpRequest(AsyncWebServerRequest* request);
 
     AsyncWebServer* _server;

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -175,6 +175,7 @@ bool ConfigurationClass::write()
         powermeter_phase["header_value"] = config.PowerMeter.Http_Phase[i].HeaderValue;
         powermeter_phase["timeout"] = config.PowerMeter.Http_Phase[i].Timeout;
         powermeter_phase["json_path"] = config.PowerMeter.Http_Phase[i].JsonPath;
+        powermeter_phase["unit"] = config.PowerMeter.Http_Phase[i].PowerUnit;
     }
 
     JsonObject powerlimiter = doc.createNestedObject("powerlimiter");
@@ -427,6 +428,7 @@ bool ConfigurationClass::read()
         strlcpy(config.PowerMeter.Http_Phase[i].HeaderValue, powermeter_phase["header_value"] | "", sizeof(config.PowerMeter.Http_Phase[i].HeaderValue));
         config.PowerMeter.Http_Phase[i].Timeout = powermeter_phase["timeout"] | POWERMETER_HTTP_TIMEOUT;
         strlcpy(config.PowerMeter.Http_Phase[i].JsonPath, powermeter_phase["json_path"] | "", sizeof(config.PowerMeter.Http_Phase[i].JsonPath));
+        config.PowerMeter.Http_Phase[i].PowerUnit = powermeter_phase["unit"] | PowerMeterHttpConfig::Unit::Watts;
     }
 
     JsonObject powerlimiter = doc["powerlimiter"];

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -420,7 +420,7 @@ bool ConfigurationClass::read()
 
         config.PowerMeter.Http_Phase[i].Enabled = powermeter_phase["enabled"] | (i == 0);
         strlcpy(config.PowerMeter.Http_Phase[i].Url, powermeter_phase["url"] | "", sizeof(config.PowerMeter.Http_Phase[i].Url));
-        config.PowerMeter.Http_Phase[i].AuthType = powermeter_phase["auth_type"] | Auth::none;
+        config.PowerMeter.Http_Phase[i].AuthType = powermeter_phase["auth_type"] | PowerMeterHttpConfig::Auth::None;
         strlcpy(config.PowerMeter.Http_Phase[i].Username, powermeter_phase["username"] | "", sizeof(config.PowerMeter.Http_Phase[i].Username));
         strlcpy(config.PowerMeter.Http_Phase[i].Password, powermeter_phase["password"] | "", sizeof(config.PowerMeter.Http_Phase[i].Password));
         strlcpy(config.PowerMeter.Http_Phase[i].HeaderKey, powermeter_phase["header_key"] | "", sizeof(config.PowerMeter.Http_Phase[i].HeaderKey));

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -176,6 +176,7 @@ bool ConfigurationClass::write()
         powermeter_phase["timeout"] = config.PowerMeter.Http_Phase[i].Timeout;
         powermeter_phase["json_path"] = config.PowerMeter.Http_Phase[i].JsonPath;
         powermeter_phase["unit"] = config.PowerMeter.Http_Phase[i].PowerUnit;
+        powermeter_phase["sign_inverted"] = config.PowerMeter.Http_Phase[i].SignInverted;
     }
 
     JsonObject powerlimiter = doc.createNestedObject("powerlimiter");
@@ -429,6 +430,7 @@ bool ConfigurationClass::read()
         config.PowerMeter.Http_Phase[i].Timeout = powermeter_phase["timeout"] | POWERMETER_HTTP_TIMEOUT;
         strlcpy(config.PowerMeter.Http_Phase[i].JsonPath, powermeter_phase["json_path"] | "", sizeof(config.PowerMeter.Http_Phase[i].JsonPath));
         config.PowerMeter.Http_Phase[i].PowerUnit = powermeter_phase["unit"] | PowerMeterHttpConfig::Unit::Watts;
+        config.PowerMeter.Http_Phase[i].SignInverted = powermeter_phase["sign_inverted"] | false;
     }
 
     JsonObject powerlimiter = doc["powerlimiter"];

--- a/src/HttpPowerMeter.cpp
+++ b/src/HttpPowerMeter.cpp
@@ -16,6 +16,8 @@ void HttpPowerMeterClass::init()
 
 float HttpPowerMeterClass::getPower(int8_t phase)
 {
+    if (phase < 1 || phase > POWERMETER_MAX_PHASES) { return 0.0; }
+
     return power[phase - 1];
 }
 

--- a/src/HttpPowerMeter.cpp
+++ b/src/HttpPowerMeter.cpp
@@ -21,10 +21,10 @@ float HttpPowerMeterClass::getPower(int8_t phase)
 
 bool HttpPowerMeterClass::updateValues()
 {
-    const CONFIG_T& config = Configuration.get();
+    auto const& config = Configuration.get();
 
     for (uint8_t i = 0; i < POWERMETER_MAX_PHASES; i++) {
-        POWERMETER_HTTP_PHASE_CONFIG_T phaseConfig = config.PowerMeter.Http_Phase[i];
+        auto const& phaseConfig = config.PowerMeter.Http_Phase[i];
 
         if (!phaseConfig.Enabled) {
             power[i] = 0.0;
@@ -32,8 +32,7 @@ bool HttpPowerMeterClass::updateValues()
         }
 
         if (i == 0 || config.PowerMeter.HttpIndividualRequests) {
-            if (!queryPhase(i, phaseConfig.Url, phaseConfig.AuthType, phaseConfig.Username, phaseConfig.Password, phaseConfig.HeaderKey, phaseConfig.HeaderValue, phaseConfig.Timeout,
-                    phaseConfig.JsonPath)) {
+            if (!queryPhase(i, phaseConfig)) {
                 MessageOutput.printf("[HttpPowerMeter] Getting the power of phase %d failed.\r\n", i + 1);
                 MessageOutput.printf("%s\r\n", httpPowerMeterError);
                 return false;
@@ -50,8 +49,7 @@ bool HttpPowerMeterClass::updateValues()
     return true;
 }
 
-bool HttpPowerMeterClass::queryPhase(int phase, const String& url, Auth authType, const char* username, const char* password,
-    const char* httpHeader, const char* httpValue, uint32_t timeout, const char* jsonPath)
+bool HttpPowerMeterClass::queryPhase(int phase, PowerMeterHttpConfig const& config)
 {
     //hostByName in WiFiGeneric fails to resolve local names. issue described in
     //https://github.com/espressif/arduino-esp32/issues/3822
@@ -63,7 +61,7 @@ bool HttpPowerMeterClass::queryPhase(int phase, const String& url, Auth authType
     String uri;
     String base64Authorization;
     uint16_t port;
-    extractUrlComponents(url, protocol, host, uri, port, base64Authorization);
+    extractUrlComponents(config.Url, protocol, host, uri, port, base64Authorization);
 
     IPAddress ipaddr((uint32_t)0);
     //first check if "host" is already an IP adress
@@ -105,43 +103,42 @@ bool HttpPowerMeterClass::queryPhase(int phase, const String& url, Auth authType
       wifiClient = std::make_unique<WiFiClient>();
     }
 
-    return httpRequest(phase, *wifiClient, ipaddr.toString(), port, uri, https, authType,  username, password, httpHeader, httpValue, timeout, jsonPath);
+    return httpRequest(phase, *wifiClient, ipaddr.toString(), port, uri, https, config);
 }
 
-bool HttpPowerMeterClass::httpRequest(int phase, WiFiClient &wifiClient, const String& host, uint16_t port, const String& uri, bool https, Auth authType, const char* username,
-    const char* password, const char* httpHeader, const char* httpValue, uint32_t timeout, const char* jsonPath)
+bool HttpPowerMeterClass::httpRequest(int phase, WiFiClient &wifiClient, const String& host, uint16_t port, const String& uri, bool https, PowerMeterHttpConfig const& config)
 {
     if(!httpClient.begin(wifiClient, host, port, uri, https)){
         snprintf_P(httpPowerMeterError, sizeof(httpPowerMeterError), PSTR("httpClient.begin() failed for %s://%s"), (https ? "https" : "http"), host.c_str());
         return false;
     }
 
-    prepareRequest(timeout, httpHeader, httpValue);
-    if (authType == Auth::digest) {
+    prepareRequest(config.Timeout, config.HeaderKey, config.HeaderValue);
+    if (config.AuthType == Auth_t::Digest) {
         const char *headers[1] = {"WWW-Authenticate"};
         httpClient.collectHeaders(headers, 1);
-    } else if (authType == Auth::basic) {
-        String authString = username;
+    } else if (config.AuthType == Auth_t::Basic) {
+        String authString = config.Username;
         authString += ":";
-        authString += password;
+        authString += config.Password;
         String auth = "Basic ";
         auth.concat(base64::encode(authString));
         httpClient.addHeader("Authorization", auth);
     }
     int httpCode = httpClient.GET();
 
-    if (httpCode == HTTP_CODE_UNAUTHORIZED && authType == Auth::digest) {
+    if (httpCode == HTTP_CODE_UNAUTHORIZED && config.AuthType == Auth_t::Digest) {
         // Handle authentication challenge
         if (httpClient.hasHeader("WWW-Authenticate")) {
             String authReq  = httpClient.header("WWW-Authenticate");
-            String authorization = getDigestAuth(authReq, String(username), String(password), "GET", String(uri), 1);
+            String authorization = getDigestAuth(authReq, String(config.Username), String(config.Password), "GET", String(uri), 1);
             httpClient.end();
             if(!httpClient.begin(wifiClient, host, port, uri, https)){
                 snprintf_P(httpPowerMeterError, sizeof(httpPowerMeterError), PSTR("httpClient.begin() failed for  %s://%s using digest auth"), (https ? "https" : "http"), host.c_str());
                 return false;
             }
 
-            prepareRequest(timeout, httpHeader, httpValue);
+            prepareRequest(config.Timeout, config.HeaderKey, config.HeaderValue);
             httpClient.addHeader("Authorization", authorization);
             httpCode = httpClient.GET();
         }

--- a/src/WebApi_powermeter.cpp
+++ b/src/WebApi_powermeter.cpp
@@ -40,6 +40,7 @@ void WebApiPowerMeterClass::decodeJsonPhaseConfig(JsonObject const& json, PowerM
     config.Timeout = json["timeout"].as<uint16_t>();
     strlcpy(config.JsonPath, json["json_path"].as<String>().c_str(), sizeof(config.JsonPath));
     config.PowerUnit = json["unit"].as<PowerMeterHttpConfig::Unit>();
+    config.SignInverted = json["sign_inverted"].as<bool>();
 }
 
 void WebApiPowerMeterClass::onStatus(AsyncWebServerRequest* request)
@@ -75,6 +76,7 @@ void WebApiPowerMeterClass::onStatus(AsyncWebServerRequest* request)
         phaseObject["timeout"] = config.PowerMeter.Http_Phase[i].Timeout;
         phaseObject["json_path"] = String(config.PowerMeter.Http_Phase[i].JsonPath);
         phaseObject["unit"] = config.PowerMeter.Http_Phase[i].PowerUnit;
+        phaseObject["sign_inverted"] = config.PowerMeter.Http_Phase[i].SignInverted;
     }
 
     response->setLength();

--- a/src/WebApi_powermeter.cpp
+++ b/src/WebApi_powermeter.cpp
@@ -39,6 +39,7 @@ void WebApiPowerMeterClass::decodeJsonPhaseConfig(JsonObject const& json, PowerM
     strlcpy(config.HeaderValue, json["header_value"].as<String>().c_str(), sizeof(config.HeaderValue));
     config.Timeout = json["timeout"].as<uint16_t>();
     strlcpy(config.JsonPath, json["json_path"].as<String>().c_str(), sizeof(config.JsonPath));
+    config.PowerUnit = json["unit"].as<PowerMeterHttpConfig::Unit>();
 }
 
 void WebApiPowerMeterClass::onStatus(AsyncWebServerRequest* request)
@@ -71,8 +72,9 @@ void WebApiPowerMeterClass::onStatus(AsyncWebServerRequest* request)
         phaseObject["password"] = String(config.PowerMeter.Http_Phase[i].Password);
         phaseObject["header_key"] = String(config.PowerMeter.Http_Phase[i].HeaderKey);
         phaseObject["header_value"] = String(config.PowerMeter.Http_Phase[i].HeaderValue);
-        phaseObject["json_path"] = String(config.PowerMeter.Http_Phase[i].JsonPath);
         phaseObject["timeout"] = config.PowerMeter.Http_Phase[i].Timeout;
+        phaseObject["json_path"] = String(config.PowerMeter.Http_Phase[i].JsonPath);
+        phaseObject["unit"] = config.PowerMeter.Http_Phase[i].PowerUnit;
     }
 
     response->setLength();

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -576,6 +576,8 @@
         "httpJsonPath": "JSON Pfad",
         "httpJsonPathDescription": "JSON Pfad um den Leistungswert zu finden. Es verwendet die Selektions-Syntax von mobizt/FirebaseJson. Beispiele gibt es oben.",
         "httpUnit": "Einheit",
+        "httpSignInverted": "Vorzeichen umkehren",
+        "httpSignInvertedHint": "Positive Werte werden als Leistungsabnahme aus dem Netz interpretiert. Diese Option muss aktiviert werden, wenn das Vorzeichen des Wertes die gegenteilige Bedeutung hat.",
         "httpTimeout": "Timeout",
         "testHttpRequest": "Testen"
     },

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -574,7 +574,8 @@
         "httpHeaderKeyDescription": "Ein individueller HTTP request header kann hier definiert werden. Das kann z.B. verwendet werden um einen eigenen Authorization header mitzugeben.",
         "httpHeaderValue": "Optional: HTTP request header - Wert",
         "httpJsonPath": "JSON Pfad",
-        "httpJsonPathDescription": "JSON Pfad um den Leistungswert zu finden. Es verwendet die Selektions-Syntax von mobizt/FirebaseJson. Beispiele gibt es unten.",
+        "httpJsonPathDescription": "JSON Pfad um den Leistungswert zu finden. Es verwendet die Selektions-Syntax von mobizt/FirebaseJson. Beispiele gibt es oben.",
+        "httpUnit": "Einheit",
         "httpTimeout": "Timeout",
         "testHttpRequest": "Testen"
     },

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -581,6 +581,8 @@
         "httpJsonPath": "JSON path",
         "httpJsonPathDescription": "JSON path to find the power value in the response. This uses the JSON path query syntax from mobizt/FirebaseJson. See above for examples.",
         "httpUnit": "Unit",
+        "httpSignInverted": "Change Sign",
+        "httpSignInvertedHint": "Is is expected that positive values denote power usage from the grid. Check this option if the sign of this value has the opposite meaning.",
         "httpTimeout": "Timeout",
         "testHttpRequest": "Run test",
         "milliSeconds": "ms"

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -578,8 +578,9 @@
         "httpHeaderKey": "Optional: HTTP request header - Key",
         "httpHeaderKeyDescription": "A custom HTTP request header can be defined. Might be useful if you have to send something like a custom Authorization header.",
         "httpHeaderValue": "Optional: HTTP request header - Value",
-        "httpJsonPath": "Json path",
-        "httpJsonPathDescription": "JSON path to find the power value in the response. This uses the JSON path query syntax from mobizt/FirebaseJson. See below for some examples.",
+        "httpJsonPath": "JSON path",
+        "httpJsonPathDescription": "JSON path to find the power value in the response. This uses the JSON path query syntax from mobizt/FirebaseJson. See above for examples.",
+        "httpUnit": "Unit",
         "httpTimeout": "Timeout",
         "testHttpRequest": "Run test",
         "milliSeconds": "ms"

--- a/webapp/src/types/PowerMeterConfig.ts
+++ b/webapp/src/types/PowerMeterConfig.ts
@@ -10,6 +10,7 @@ export interface PowerMeterHttpPhaseConfig {
     json_path: string;
     timeout: number;
     unit: number;
+    sign_inverted: boolean;
 }
 
 export interface PowerMeterConfig {

--- a/webapp/src/types/PowerMeterConfig.ts
+++ b/webapp/src/types/PowerMeterConfig.ts
@@ -9,6 +9,7 @@ export interface PowerMeterHttpPhaseConfig {
     header_value: string;
     json_path: string;
     timeout: number;
+    unit: number;
 }
 
 export interface PowerMeterConfig {

--- a/webapp/src/views/PowerMeterAdminView.vue
+++ b/webapp/src/views/PowerMeterAdminView.vue
@@ -202,6 +202,12 @@
                                 </div>
                             </div>
 
+                            <InputElement
+                                :label="$t('powermeteradmin.httpSignInverted')"
+                                v-model="http_phase.sign_inverted"
+                                :tooltip="$t('powermeteradmin.httpSignInvertedHint')"
+                                type="checkbox" />
+
                             <div class="text-center mb-3">
                                 <button type="button" class="btn btn-danger" @click="testHttpRequest(index)">
                                     {{ $t('powermeteradmin.testHttpRequest') }}

--- a/webapp/src/views/PowerMeterAdminView.vue
+++ b/webapp/src/views/PowerMeterAdminView.vue
@@ -189,6 +189,19 @@
                                 placeholder="total_power"
                                 :tooltip="$t('powermeteradmin.httpJsonPathDescription')" />
 
+                            <div class="row mb-3">
+                                <label for="power_unit" class="col-sm-2 col-form-label">
+                                    {{ $t('powermeteradmin.httpUnit') }}
+                                </label>
+                                <div class="col-sm-10">
+                                    <select id="power_unit" class="form-select" v-model="http_phase.unit">
+                                        <option value="1">mW</option>
+                                        <option value="0">W</option>
+                                        <option value="2">kW</option>
+                                    </select>
+                                </div>
+                            </div>
+
                             <div class="text-center mb-3">
                                 <button type="button" class="btn btn-danger" @click="testHttpRequest(index)">
                                     {{ $t('powermeteradmin.testHttpRequest') }}


### PR DESCRIPTION
This changeset allows to
* select the unit of a value retrieved using the HTTP(S)+JSON power meter implementation. Supported units are mW (milli Watt), W (Watt, the default) and kW (kilo Watt).
* instruct to change the retrieved value's sign such that it is positive when it means to indicate power consumption.

Closes #451 and #735 and #882.