### PR TITLE
Feature: Added "Tibber" Power Meter to support Tibber Pulse (via Tibber Bridge)

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -77,6 +77,14 @@ struct POWERMETER_HTTP_PHASE_CONFIG_T {
 };
 using PowerMeterHttpConfig = struct POWERMETER_HTTP_PHASE_CONFIG_T;
 
+struct POWERMETER_TIBBER_CONFIG_T {
+    char Url[POWERMETER_MAX_HTTP_URL_STRLEN + 1];
+    char Username[POWERMETER_MAX_USERNAME_STRLEN + 1];
+    char Password[POWERMETER_MAX_USERNAME_STRLEN + 1];
+    uint16_t Timeout;
+};
+using PowerMeterTibberConfig = struct POWERMETER_TIBBER_CONFIG_T;
+
 struct CONFIG_T {
     struct {
         uint32_t Version;
@@ -199,6 +207,7 @@ struct CONFIG_T {
         uint32_t HttpInterval;
         bool HttpIndividualRequests;
         PowerMeterHttpConfig Http_Phase[POWERMETER_MAX_PHASES];
+        PowerMeterTibberConfig Tibber;
     } PowerMeter;
 
     struct {

--- a/include/PowerMeter.h
+++ b/include/PowerMeter.h
@@ -26,13 +26,19 @@ public:
         SDM3PH = 2,
         HTTP = 3,
         SML = 4,
-        SMAHM2 = 5
+        SMAHM2 = 5,
+        TIBBER = 6
     };
     void init(Scheduler& scheduler);
     float getPowerTotal(bool forceUpdate = true);
     uint32_t getLastPowerMeterUpdate();
     bool isDataValid();
 
+    const std::list<OBISHandler> smlHandlerList{
+        {{0x01, 0x00, 0x10, 0x07, 0x00, 0xff}, &smlOBISW, &_powerMeter1Power},
+        {{0x01, 0x00, 0x01, 0x08, 0x00, 0xff}, &smlOBISWh, &_powerMeterImport},
+        {{0x01, 0x00, 0x02, 0x08, 0x00, 0xff}, &smlOBISWh, &_powerMeterExport}
+    };
 private:
     void loop();
     void mqtt();
@@ -68,11 +74,6 @@ private:
     void readPowerMeter();
 
     bool smlReadLoop();
-    const std::list<OBISHandler> smlHandlerList{
-        {{0x01, 0x00, 0x10, 0x07, 0x00, 0xff}, &smlOBISW, &_powerMeter1Power},
-        {{0x01, 0x00, 0x01, 0x08, 0x00, 0xff}, &smlOBISWh, &_powerMeterImport},
-        {{0x01, 0x00, 0x02, 0x08, 0x00, 0xff}, &smlOBISWh, &_powerMeterExport}
-    };
 };
 
 extern PowerMeterClass PowerMeter;

--- a/include/TibberPowerMeter.h
+++ b/include/TibberPowerMeter.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <stdint.h>
+#include <Arduino.h>
+#include <HTTPClient.h>
+#include "Configuration.h"
+
+class TibberPowerMeterClass {
+public:
+    bool updateValues();
+    char tibberPowerMeterError[256];
+    bool query(PowerMeterTibberConfig const& config);
+
+private:
+    HTTPClient httpClient;
+    String httpResponse;
+    bool httpRequest(WiFiClient &wifiClient, const String& host, uint16_t port, const String& uri, bool https, PowerMeterTibberConfig const& config);
+    bool extractUrlComponents(String url, String& _protocol, String& _hostname, String& _uri, uint16_t& uint16_t, String& _base64Authorization);
+    void prepareRequest(uint32_t timeout);
+};
+
+extern TibberPowerMeterClass TibberPowerMeter;

--- a/include/WebApi_powermeter.h
+++ b/include/WebApi_powermeter.h
@@ -15,7 +15,9 @@ private:
     void onAdminGet(AsyncWebServerRequest* request);
     void onAdminPost(AsyncWebServerRequest* request);
     void decodeJsonPhaseConfig(JsonObject const& json, PowerMeterHttpConfig& config) const;
+    void decodeJsonTibberConfig(JsonObject const& json, PowerMeterTibberConfig& config) const;
     void onTestHttpRequest(AsyncWebServerRequest* request);
+    void onTestTibberRequest(AsyncWebServerRequest* request);
 
     AsyncWebServer* _server;
 };

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -158,6 +158,12 @@ bool ConfigurationClass::write()
     powermeter["sdmaddress"] = config.PowerMeter.SdmAddress;
     powermeter["http_individual_requests"] = config.PowerMeter.HttpIndividualRequests;
 
+    JsonObject tibber = powermeter["tibber"].to<JsonObject>();
+    tibber["url"] = config.PowerMeter.Tibber.Url;
+    tibber["username"] = config.PowerMeter.Tibber.Username;
+    tibber["password"] = config.PowerMeter.Tibber.Password;
+    tibber["timeout"] = config.PowerMeter.Tibber.Timeout;
+
     JsonArray powermeter_http_phases = powermeter["http_phases"].to<JsonArray>();
     for (uint8_t i = 0; i < POWERMETER_MAX_PHASES; i++) {
         JsonObject powermeter_phase = powermeter_http_phases.add<JsonObject>();
@@ -416,6 +422,12 @@ bool ConfigurationClass::read()
     config.PowerMeter.SdmBaudrate =  powermeter["sdmbaudrate"] | POWERMETER_SDMBAUDRATE;
     config.PowerMeter.SdmAddress =  powermeter["sdmaddress"] | POWERMETER_SDMADDRESS;
     config.PowerMeter.HttpIndividualRequests = powermeter["http_individual_requests"] | false;
+
+    JsonObject tibber = powermeter["tibber"];
+    strlcpy(config.PowerMeter.Tibber.Url, tibber["url"] | "", sizeof(config.PowerMeter.Tibber.Url));
+    strlcpy(config.PowerMeter.Tibber.Username, tibber["username"] | "", sizeof(config.PowerMeter.Tibber.Username));
+    strlcpy(config.PowerMeter.Tibber.Password, tibber["password"] | "", sizeof(config.PowerMeter.Tibber.Password));
+    config.PowerMeter.Tibber.Timeout = tibber["timeout"] | POWERMETER_HTTP_TIMEOUT;
 
     JsonArray powermeter_http_phases = powermeter["http_phases"];
     for (uint8_t i = 0; i < POWERMETER_MAX_PHASES; i++) {

--- a/src/PowerMeter.cpp
+++ b/src/PowerMeter.cpp
@@ -6,6 +6,7 @@
 #include "Configuration.h"
 #include "PinMapping.h"
 #include "HttpPowerMeter.h"
+#include "TibberPowerMeter.h"
 #include "MqttSettings.h"
 #include "NetworkSettings.h"
 #include "MessageOutput.h"
@@ -95,6 +96,9 @@ void PowerMeterClass::init(Scheduler& scheduler)
 
     case Source::SMAHM2:
         SMA_HM.init(scheduler, config.PowerMeter.VerboseLogging);
+        break;
+
+    case Source::TIBBER:
         break;
     }
 }
@@ -273,6 +277,11 @@ void PowerMeterClass::readPowerMeter()
         _powerMeter2Power = SMA_HM.getPowerL2();
         _powerMeter3Power = SMA_HM.getPowerL3();
         _lastPowerMeterUpdate = millis();
+    }
+    else if (configuredSource == Source::TIBBER) {
+        if (TibberPowerMeter.updateValues()) {
+            _lastPowerMeterUpdate = millis();
+        }
     }
 }
 

--- a/src/TibberPowerMeter.cpp
+++ b/src/TibberPowerMeter.cpp
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "Configuration.h"
+#include "TibberPowerMeter.h"
+#include "MessageOutput.h"
+#include <WiFiClientSecure.h>
+#include <base64.h>
+#include <ESPmDNS.h>
+#include <PowerMeter.h>
+
+bool TibberPowerMeterClass::updateValues()
+{
+    auto const& config = Configuration.get();
+
+    auto const& tibberConfig = config.PowerMeter.Tibber;
+
+    if (!query(tibberConfig)) {
+        MessageOutput.printf("[TibberPowerMeter] Getting the power of tibber failed.\r\n");
+        MessageOutput.printf("%s\r\n", tibberPowerMeterError);
+        return false;
+    }
+
+    return true;
+}
+
+bool TibberPowerMeterClass::query(PowerMeterTibberConfig const& config)
+{
+    //hostByName in WiFiGeneric fails to resolve local names. issue described in
+    //https://github.com/espressif/arduino-esp32/issues/3822
+    //and in depth analyzed in https://github.com/espressif/esp-idf/issues/2507#issuecomment-761836300
+    //in conclusion: we cannot rely on httpClient.begin(*wifiClient, url) to resolve IP adresses.
+    //have to do it manually here. Feels Hacky...
+    String protocol;
+    String host;
+    String uri;
+    String base64Authorization;
+    uint16_t port;
+    extractUrlComponents(config.Url, protocol, host, uri, port, base64Authorization);
+
+    IPAddress ipaddr((uint32_t)0);
+    //first check if "host" is already an IP adress
+    if (!ipaddr.fromString(host))
+    {
+        //"host"" is not an IP address so try to resolve the IP adress
+        //first try locally via mDNS, then via DNS. WiFiGeneric::hostByName() will spam the console if done the otherway around.
+        const bool mdnsEnabled = Configuration.get().Mdns.Enabled;
+        if (!mdnsEnabled) {
+            snprintf_P(tibberPowerMeterError, sizeof(tibberPowerMeterError), PSTR("Error resolving host %s via DNS, try to enable mDNS in Network Settings"), host.c_str());
+            //ensure we try resolving via DNS even if mDNS is disabled
+            if(!WiFiGenericClass::hostByName(host.c_str(), ipaddr)){
+                    snprintf_P(tibberPowerMeterError, sizeof(tibberPowerMeterError), PSTR("Error resolving host %s via DNS"), host.c_str());
+                }
+        }
+        else
+        {
+            ipaddr = MDNS.queryHost(host);
+            if (ipaddr == INADDR_NONE){
+                snprintf_P(tibberPowerMeterError, sizeof(tibberPowerMeterError), PSTR("Error resolving host %s via mDNS"), host.c_str());
+                //when we cannot find local server via mDNS, try resolving via DNS
+                if(!WiFiGenericClass::hostByName(host.c_str(), ipaddr)){
+                    snprintf_P(tibberPowerMeterError, sizeof(tibberPowerMeterError), PSTR("Error resolving host %s via DNS"), host.c_str());
+                }
+            }
+        }
+    }
+
+    // secureWifiClient MUST be created before HTTPClient
+    // see discussion: https://github.com/helgeerbe/OpenDTU-OnBattery/issues/381
+    std::unique_ptr<WiFiClient> wifiClient;
+
+    bool https = protocol == "https";
+    if (https) {
+      auto secureWifiClient = std::make_unique<WiFiClientSecure>();
+      secureWifiClient->setInsecure();
+      wifiClient = std::move(secureWifiClient);
+    } else {
+      wifiClient = std::make_unique<WiFiClient>();
+    }
+
+    return httpRequest(*wifiClient, ipaddr.toString(), port, uri, https, config);
+}
+
+bool TibberPowerMeterClass::httpRequest(WiFiClient &wifiClient, const String& host, uint16_t port, const String& uri, bool https, PowerMeterTibberConfig const& config)
+{
+    if(!httpClient.begin(wifiClient, host, port, uri, https)){
+        snprintf_P(tibberPowerMeterError, sizeof(tibberPowerMeterError), PSTR("httpClient.begin() failed for %s://%s"), (https ? "https" : "http"), host.c_str());
+        return false;
+    }
+
+    prepareRequest(config.Timeout);
+
+    String authString = config.Username;
+    authString += ":";
+    authString += config.Password;
+    String auth = "Basic ";
+    auth.concat(base64::encode(authString));
+    httpClient.addHeader("Authorization", auth);
+
+    int httpCode = httpClient.GET();
+
+    if (httpCode <= 0) {
+        snprintf_P(tibberPowerMeterError, sizeof(tibberPowerMeterError), PSTR("HTTP Error %s"), httpClient.errorToString(httpCode).c_str());
+        return false;
+    }
+
+    if (httpCode != HTTP_CODE_OK) {
+        snprintf_P(tibberPowerMeterError, sizeof(tibberPowerMeterError), PSTR("Bad HTTP code: %d"), httpCode);
+        return false;
+    }
+
+    while (httpClient.getStream().available()) {
+        double readVal = 0;
+        unsigned char smlCurrentChar = httpClient.getStream().read();
+        sml_states_t smlCurrentState = smlState(smlCurrentChar);
+        if (smlCurrentState == SML_LISTEND) {
+            for (auto& handler: PowerMeter.smlHandlerList) {
+                if (smlOBISCheck(handler.OBIS)) {
+                    handler.Fn(readVal);
+                    *handler.Arg = readVal;
+                }
+            }
+        }
+    }
+    httpClient.end();
+
+    return true;
+}
+
+//extract url component as done by httpClient::begin(String url, const char* expectedProtocol) https://github.com/espressif/arduino-esp32/blob/da6325dd7e8e152094b19fe63190907f38ef1ff0/libraries/HTTPClient/src/HTTPClient.cpp#L250
+bool TibberPowerMeterClass::extractUrlComponents(String url, String& _protocol, String& _host, String& _uri, uint16_t& _port, String& _base64Authorization)
+{
+    // check for : (http: or https:
+    int index = url.indexOf(':');
+    if(index < 0) {
+        snprintf_P(tibberPowerMeterError, sizeof(tibberPowerMeterError), PSTR("failed to parse protocol"));
+        return false;
+    }
+
+    _protocol = url.substring(0, index);
+
+    //initialize port to default values for http or https.
+    //port will be overwritten below in case port is explicitly defined
+    _port = (_protocol == "https" ? 443 : 80);
+
+    url.remove(0, (index + 3)); // remove http:// or https://
+
+    index = url.indexOf('/');
+    if (index == -1) {
+        index = url.length();
+        url += '/';
+    }
+    String host = url.substring(0, index);
+    url.remove(0, index); // remove host part
+
+    // get Authorization
+    index = host.indexOf('@');
+    if(index >= 0) {
+        // auth info
+        String auth = host.substring(0, index);
+        host.remove(0, index + 1); // remove auth part including @
+        _base64Authorization = base64::encode(auth);
+    }
+
+    // get port
+    index = host.indexOf(':');
+    String the_host;
+    if(index >= 0) {
+        the_host = host.substring(0, index); // hostname
+        host.remove(0, (index + 1)); // remove hostname + :
+        _port = host.toInt(); // get port
+    } else {
+        the_host = host;
+    }
+
+    _host = the_host;
+    _uri = url;
+    return true;
+}
+
+void TibberPowerMeterClass::prepareRequest(uint32_t timeout) {
+    httpClient.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+    httpClient.setUserAgent("OpenDTU-OnBattery");
+    httpClient.setConnectTimeout(timeout);
+    httpClient.setTimeout(timeout);
+    httpClient.addHeader("Content-Type", "application/json");
+    httpClient.addHeader("Accept", "application/json");
+}
+
+TibberPowerMeterClass TibberPowerMeter;

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -564,6 +564,7 @@
         "typeHTTP": "HTTP(S) + JSON",
         "typeSML": "SML (OBIS 16.7.0)",
         "typeSMAHM2": "SMA Homemanager 2.0",
+        "typeTIBBER": "Tibber Pulse (via Tibber Bridge)",
         "MqttTopicPowerMeter1": "MQTT topic - Stromzähler #1",
         "MqttTopicPowerMeter2": "MQTT topic - Stromzähler #2 (Optional)",
         "MqttTopicPowerMeter3": "MQTT topic - Stromzähler #3 (Optional)",
@@ -588,7 +589,8 @@
         "httpSignInverted": "Vorzeichen umkehren",
         "httpSignInvertedHint": "Positive Werte werden als Leistungsabnahme aus dem Netz interpretiert. Diese Option muss aktiviert werden, wenn das Vorzeichen des Wertes die gegenteilige Bedeutung hat.",
         "httpTimeout": "Timeout",
-        "testHttpRequest": "Testen"
+        "testHttpRequest": "Testen",
+        "TIBBER": "Tibber Pulse (via Tibber Bridge) - Konfiguration"
     },
     "powerlimiteradmin": {
         "PowerLimiterSettings": "Dynamic Power Limiter Einstellungen",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -566,6 +566,7 @@
         "typeHTTP": "HTTP(s) + JSON",
         "typeSML": "SML (OBIS 16.7.0)",
         "typeSMAHM2": "SMA Homemanager 2.0",
+        "typeTIBBER": "Tibber Pulse (via Tibber Bridge)",
         "MqttTopicPowerMeter1": "MQTT topic - Power meter #1",
         "MqttTopicPowerMeter2": "MQTT topic - Power meter #2",
         "MqttTopicPowerMeter3": "MQTT topic - Power meter #3",
@@ -594,7 +595,8 @@
         "httpSignInvertedHint": "Is is expected that positive values denote power usage from the grid. Check this option if the sign of this value has the opposite meaning.",
         "httpTimeout": "Timeout",
         "testHttpRequest": "Run test",
-        "milliSeconds": "ms"
+        "milliSeconds": "ms",
+        "TIBBER": "Tibber Pulse (via Tibber Bridge) - Configuration"
     },
     "powerlimiteradmin": {
         "PowerLimiterSettings": "Dynamic Power Limiter Settings",

--- a/webapp/src/types/PowerMeterConfig.ts
+++ b/webapp/src/types/PowerMeterConfig.ts
@@ -13,6 +13,13 @@ export interface PowerMeterHttpPhaseConfig {
     sign_inverted: boolean;
 }
 
+export interface PowerMeterTibberConfig {
+    url: string;
+    username: string;
+    password: string;
+    timeout: number;
+}
+
 export interface PowerMeterConfig {
     enabled: boolean;
     verbose_logging: boolean;
@@ -25,4 +32,5 @@ export interface PowerMeterConfig {
     sdmaddress: number;
     http_individual_requests: boolean;
     http_phases: Array<PowerMeterHttpPhaseConfig>;
+    tibber: PowerMeterTibberConfig;
 }


### PR DESCRIPTION
I've extended the "HTTP(S) + JSON" Power Meter (#153) to support the [Tibber Pulse](https://tibber.com/de/store/produkt/pulse-ir). The current power drawn from the grid is fetched using the local web server from the Tibber Bridge. No external requests through the internet (Tibber API).

Instructions on how to enable the web server permanently are also included in German and English:
<img width="980" alt="Bildschirmfoto 2024-04-23 um 19 40 34" src="https://github.com/helgeerbe/OpenDTU-OnBattery/assets/5238390/0210fd08-3da5-4fe3-81da-e72e2b8babdb">

Thank you to [gvzdus](https://forum.fhem.de/index.php?topic=133358.0) and the discussion #123!

Pre-compiled binaries to directly test the feature:
[opendtu-onbattery-generic_esp32.bin.zip](https://github.com/helgeerbe/OpenDTU-OnBattery/files/15080621/opendtu-onbattery-generic_esp32.bin.zip)
[opendtu-onbattery-generic_esp32.factory.bin.zip](https://github.com/helgeerbe/OpenDTU-OnBattery/files/15080622/opendtu-onbattery-generic_esp32.factory.bin.zip)
