### PR TITLE
Victron pin define fix

### DIFF
--- a/src/PinMapping.cpp
+++ b/src/PinMapping.cpp
@@ -94,6 +94,14 @@
 #define VICTRON_PIN_RX -1
 #endif
 
+#ifndef VICTRON_PIN_TX2
+#define VICTRON_PIN_TX2 -1
+#endif
+
+#ifndef VICTRON_PIN_RX2
+#define VICTRON_PIN_RX2 -1
+#endif
+
 #ifndef BATTERY_PIN_RX
 #define BATTERY_PIN_RX -1
 #endif
@@ -284,8 +292,8 @@ bool PinMappingClass::init(const String& deviceMapping)
             // OpenDTU-OnBattery-specific pins below
             _pinMapping.victron_rx = doc[i]["victron"]["rx"] | VICTRON_PIN_RX;
             _pinMapping.victron_tx = doc[i]["victron"]["tx"] | VICTRON_PIN_TX;
-            _pinMapping.victron_rx2 = doc[i]["victron"]["rx2"] | VICTRON_PIN_RX;
-            _pinMapping.victron_tx2 = doc[i]["victron"]["tx2"] | VICTRON_PIN_TX;
+            _pinMapping.victron_rx2 = doc[i]["victron"]["rx2"] | VICTRON_PIN_RX2;
+            _pinMapping.victron_tx2 = doc[i]["victron"]["tx2"] | VICTRON_PIN_TX2;
 
             _pinMapping.battery_rx = doc[i]["battery"]["rx"] | BATTERY_PIN_RX;
             _pinMapping.battery_rxen = doc[i]["battery"]["rxen"] | BATTERY_PIN_RXEN;


### PR DESCRIPTION
Victron pins RX2 and TX2 are incorrectly initialized. Proposed fix for issue described here:
https://github.com/helgeerbe/OpenDTU-OnBattery/issues/916
