### PR TITLE
battery interface: use HW serial 0 on ESP32-C3 or S3

### DIFF
--- a/include/JkBmsController.h
+++ b/include/JkBmsController.h
@@ -19,7 +19,9 @@ class Controller : public BatteryProvider {
         void deinit() final;
         void loop() final;
         std::shared_ptr<BatteryStats> getStats() const final { return _stats; }
-        bool usesHwPort2() const final { return true; }
+        bool usesHwPort2() const final {
+            return ARDUINO_USB_CDC_ON_BOOT != 1;
+        }
 
     private:
         enum class Status : unsigned {

--- a/include/VictronSmartShunt.h
+++ b/include/VictronSmartShunt.h
@@ -9,7 +9,9 @@ public:
     void deinit() final { }
     void loop() final;
     std::shared_ptr<BatteryStats> getStats() const final { return _stats; }
-    bool usesHwPort2() const final { return true; }
+    bool usesHwPort2() const final {
+        return ARDUINO_USB_CDC_ON_BOOT != 1;
+    }
 
 private:
     uint32_t _lastUpdate = 0;

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -65,6 +65,7 @@ template<typename T>
 void VeDirectFrameHandler<T>::init(char const* who, int8_t rx, int8_t tx, Print* msgOut, bool verboseLogging, uint16_t hwSerialPort)
 {
 	_vedirectSerial = std::make_unique<HardwareSerial>(hwSerialPort);
+	_vedirectSerial->end(); // make sure the UART will be re-initialized
 	_vedirectSerial->begin(19200, SERIAL_8N1, rx, tx);
 	_vedirectSerial->flush();
 	_canSend = (tx != -1);

--- a/lib/VeDirectFrameHandler/VeDirectShuntController.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectShuntController.cpp
@@ -5,7 +5,8 @@ VeDirectShuntController VeDirectShunt;
 
 void VeDirectShuntController::init(int8_t rx, int8_t tx, Print* msgOut, bool verboseLogging)
 {
-	VeDirectFrameHandler::init("SmartShunt", rx, tx, msgOut, verboseLogging, 2);
+	VeDirectFrameHandler::init("SmartShunt", rx, tx, msgOut, verboseLogging,
+			((ARDUINO_USB_CDC_ON_BOOT != 1)?2:0));
 }
 
 bool VeDirectShuntController::processTextDataDerived(std::string const& name, std::string const& value)

--- a/src/JkBmsController.cpp
+++ b/src/JkBmsController.cpp
@@ -198,7 +198,7 @@ class DummySerial {
 };
 DummySerial HwSerial;
 #else
-HardwareSerial HwSerial(2);
+HardwareSerial HwSerial((ARDUINO_USB_CDC_ON_BOOT != 1)?2:0);
 #endif
 
 namespace JkBms {
@@ -220,6 +220,7 @@ bool Controller::init(bool verboseLogging)
         return false;
     }
 
+    HwSerial.end(); // make sure the UART will be re-initialized
     HwSerial.begin(115200, SERIAL_8N1, pin.battery_rx, pin.battery_tx);
     HwSerial.flush();
 


### PR DESCRIPTION
this allows to use two VE.Direct interfaces, as there is no conflict regarding HW serial port 2 after making the battery interfaces use serial port 0 on devices with USB CDC. on those chips HW serial 0 is free to be used since serial messages are written through the USB interface directly.