### PR TITLE
Adding addtional values to SML Powermeter exposed via MQTT

### DIFF
--- a/include/PowerMeter.h
+++ b/include/PowerMeter.h
@@ -47,12 +47,16 @@ private:
     // Used in Power limiter for safety check
     uint32_t _lastPowerMeterUpdate;
 
+    float _powerMeterTotalPower = 0.0;
     float _powerMeter1Power = 0.0;
     float _powerMeter2Power = 0.0;
     float _powerMeter3Power = 0.0;
     float _powerMeter1Voltage = 0.0;
     float _powerMeter2Voltage = 0.0;
     float _powerMeter3Voltage = 0.0;
+    float _powerMeter1Current = 0.0;
+    float _powerMeter2Current = 0.0;
+    float _powerMeter3Current = 0.0;
     float _powerMeterImport = 0.0;
     float _powerMeterExport = 0.0;
 
@@ -67,9 +71,18 @@ private:
 
     bool smlReadLoop();
     const std::list<OBISHandler> smlHandlerList{
-        {{0x01, 0x00, 0x10, 0x07, 0x00, 0xff}, &smlOBISW, &_powerMeter1Power},
+        {{0x01, 0x00, 0x10, 0x07, 0x00, 0xff}, &smlOBISW, &_powerMeterTotalPower},
+        {{0x01, 0x00, 0x24, 0x07, 0x00, 0xff}, &smlOBISW, &_powerMeter1Power}, 
+        {{0x01, 0x00, 0x38, 0x07, 0x00, 0xff}, &smlOBISW, &_powerMeter2Power}, 
+        {{0x01, 0x00, 0x4c, 0x07, 0x00, 0xff}, &smlOBISW, &_powerMeter3Power},
         {{0x01, 0x00, 0x01, 0x08, 0x00, 0xff}, &smlOBISWh, &_powerMeterImport},
-        {{0x01, 0x00, 0x02, 0x08, 0x00, 0xff}, &smlOBISWh, &_powerMeterExport}
+        {{0x01, 0x00, 0x02, 0x08, 0x00, 0xff}, &smlOBISWh, &_powerMeterExport}, 
+        {{0x01, 0x00, 0x20, 0x07, 0x00, 0xff}, &smlOBISVolt, &_powerMeter1Voltage}, 
+        {{0x01, 0x00, 0x34, 0x07, 0x00, 0xff}, &smlOBISVolt, &_powerMeter2Voltage}, 
+        {{0x01, 0x00, 0x48, 0x07, 0x00, 0xff}, &smlOBISVolt, &_powerMeter3Voltage},
+        {{0x01, 0x00, 0x1f, 0x07, 0x00, 0xff}, &smlOBISAmpere, &_powerMeter1Current}, 
+        {{0x01, 0x00, 0x33, 0x07, 0x00, 0xff}, &smlOBISAmpere, &_powerMeter2Current}, 
+        {{0x01, 0x00, 0x47, 0x07, 0x00, 0xff}, &smlOBISAmpere, &_powerMeter3Current}
     };
 };
 

--- a/src/PowerMeter.cpp
+++ b/src/PowerMeter.cpp
@@ -158,18 +158,20 @@ void PowerMeterClass::mqtt()
     if (!MqttSettings.getConnected()) { return; }
 
     String topic = "powermeter";
-    auto totalPower = getPowerTotal();
 
     std::lock_guard<std::mutex> l(_mutex);
     MqttSettings.publish(topic + "/power1", String(_powerMeter1Power));
     MqttSettings.publish(topic + "/power2", String(_powerMeter2Power));
     MqttSettings.publish(topic + "/power3", String(_powerMeter3Power));
-    MqttSettings.publish(topic + "/powertotal", String(totalPower));
+    MqttSettings.publish(topic + "/powertotal", String(_powerMeterTotalPower));
     MqttSettings.publish(topic + "/voltage1", String(_powerMeter1Voltage));
     MqttSettings.publish(topic + "/voltage2", String(_powerMeter2Voltage));
     MqttSettings.publish(topic + "/voltage3", String(_powerMeter3Voltage));
-    MqttSettings.publish(topic + "/import", String(_powerMeterImport));
-    MqttSettings.publish(topic + "/export", String(_powerMeterExport));
+    MqttSettings.publish(topic + "/potential1", String(_powerMeter1Current));
+    MqttSettings.publish(topic + "/potential2", String(_powerMeter2Current));
+    MqttSettings.publish(topic + "/potential3", String(_powerMeter3Current));
+    MqttSettings.publish(topic + "/import", String(_powerMeterImport * 0.001));
+    MqttSettings.publish(topic + "/export", String(_powerMeterExport * 0.001));
 }
 
 void PowerMeterClass::loop()


### PR DESCRIPTION
In the current version of opendtu on battery only basic info was extracted from sml powermeters. This pull request adds Voltage for L1-L3, Current L1-L3, Power per phase and totalPower values to MQTT. Import and Export values are rounded as well.

![image](https://github.com/helgeerbe/OpenDTU-OnBattery/assets/6172385/6102336c-ca20-4c8d-a428-e09201d6b0d3)
