### PR TITLE
Remove redundant libraries (FirebaseJson and Crypto)

### DIFF
--- a/include/HttpPowerMeter.h
+++ b/include/HttpPowerMeter.h
@@ -26,7 +26,7 @@ private:
     String extractParam(String& authReq, const String& param, const char delimit);
     String getcNonce(const int len);
     String getDigestAuth(String& authReq, const String& username, const String& password, const String& method, const String& uri, unsigned int counter);
-    bool tryGetFloatValueForPhase(int phase, const char* jsonPath, Unit_t unit, bool signInverted);
+    bool tryGetFloatValueForPhase(int phase, String jsonPath, Unit_t unit, bool signInverted);
     void prepareRequest(uint32_t timeout, const char* httpHeader, const char* httpValue);
     String sha256(const String& data);
 };

--- a/platformio.ini
+++ b/platformio.ini
@@ -47,7 +47,6 @@ lib_deps =
     https://github.com/coryjfowler/MCP_CAN_lib
     plerup/EspSoftwareSerial @ ^8.0.1
     https://github.com/dok-net/ghostl @ ^1.0.1
-	rweather/Crypto@^0.4.0
 
 extra_scripts =
     pre:pio-scripts/auto_firmware_version.py

--- a/platformio.ini
+++ b/platformio.ini
@@ -47,7 +47,6 @@ lib_deps =
     https://github.com/coryjfowler/MCP_CAN_lib
     plerup/EspSoftwareSerial @ ^8.0.1
     https://github.com/dok-net/ghostl @ ^1.0.1
-    mobizt/FirebaseJson @ ^3.0.6
 	rweather/Crypto@^0.4.0
 
 extra_scripts =

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -577,7 +577,7 @@
         "httpHeaderKeyDescription": "Ein individueller HTTP request header kann hier definiert werden. Das kann z.B. verwendet werden um einen eigenen Authorization header mitzugeben.",
         "httpHeaderValue": "Optional: HTTP request header - Wert",
         "httpJsonPath": "JSON Pfad",
-        "httpJsonPathDescription": "JSON Pfad um den Leistungswert zu finden. Es verwendet die Selektions-Syntax von mobizt/FirebaseJson. Beispiele gibt es oben.",
+        "httpJsonPathDescription": "Anwendungsspezifischer JSON-Pfad um den Leistungswert in the HTTP(S) Antwort zu finden, z.B. 'power/total/watts' oder nur 'total'.",
         "httpUnit": "Einheit",
         "httpSignInverted": "Vorzeichen umkehren",
         "httpSignInvertedHint": "Positive Werte werden als Leistungsabnahme aus dem Netz interpretiert. Diese Option muss aktiviert werden, wenn das Vorzeichen des Wertes die gegenteilige Bedeutung hat.",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -582,7 +582,7 @@
         "httpHeaderKeyDescription": "A custom HTTP request header can be defined. Might be useful if you have to send something like a custom Authorization header.",
         "httpHeaderValue": "Optional: HTTP request header - Value",
         "httpJsonPath": "JSON path",
-        "httpJsonPathDescription": "JSON path to find the power value in the response. This uses the JSON path query syntax from mobizt/FirebaseJson. See above for examples.",
+        "httpJsonPathDescription": "Application specific JSON path to find the power value in the HTTP(S) response, e.g., 'power/total/watts' or simply 'total'.",
         "httpUnit": "Unit",
         "httpSignInverted": "Change Sign",
         "httpSignInvertedHint": "Is is expected that positive values denote power usage from the grid. Check this option if the sign of this value has the opposite meaning.",

--- a/webapp/src/views/PowerMeterAdminView.vue
+++ b/webapp/src/views/PowerMeterAdminView.vue
@@ -116,11 +116,9 @@
 
                         <h2>JSON path examples:</h2>
                         <ul>
-                            <li>total_power - { "othervalue": "blah", "total_power": 123.4 }</li>
-                            <li>testarray/[2]/myvalue - { "testarray": [ {}, { "power": 123.4 } ] }</li>
+                            <li><code>power/total/watts</code> - Finds 123.4 in <code>{ "power": { "phase1": { "factor": 0.98, "watts": 42 }, "total": { "watts": 123.4 } } }</code></li>
+                            <li><code>total</code> - Finds 123.4 in <code>{ "othervalue": 66, "total": 123.4 }</code></li>
                         </ul>
-
-                        More info: <a href="https://github.com/mobizt/FirebaseJson">https://github.com/mobizt/FirebaseJson</a>
                     </div>
 
                     <CardElement


### PR DESCRIPTION
The firmware for environments `generic` and `generic_esp32` (and probably more) finally became to large, see #950.

This changeset removes the FirebaseJson and the rweather/Crypto libs from the build and implements the functionality they provided using existing libs. This saves nearly 20kB of flash memory. The firmware now works again on non-S3 ESP32.

Closes #950.