### PR TITLE
Feature: Add support for a third Victron MPPT charge controller

### DIFF
--- a/include/Battery.h
+++ b/include/Battery.h
@@ -14,7 +14,6 @@ public:
     virtual void deinit() = 0;
     virtual void loop() = 0;
     virtual std::shared_ptr<BatteryStats> getStats() const = 0;
-    virtual int usedHwUart() const { return -1; } // -1 => no HW UART used
 };
 
 class BatteryClass {

--- a/include/Battery.h
+++ b/include/Battery.h
@@ -14,7 +14,7 @@ public:
     virtual void deinit() = 0;
     virtual void loop() = 0;
     virtual std::shared_ptr<BatteryStats> getStats() const = 0;
-    virtual bool usesHwPort2() const { return false; }
+    virtual int usedHwUart() const { return -1; } // -1 => no HW UART used
 };
 
 class BatteryClass {

--- a/include/JkBmsController.h
+++ b/include/JkBmsController.h
@@ -7,11 +7,11 @@
 #include "Battery.h"
 #include "JkBmsSerialMessage.h"
 
+//#define JKBMS_DUMMY_SERIAL
+
 class DataPointContainer;
 
 namespace JkBms {
-
-uint8_t constexpr HwSerialPort = ((ARDUINO_USB_CDC_ON_BOOT != 1)?2:0);
 
 class Controller : public BatteryProvider {
     public:
@@ -21,9 +21,16 @@ class Controller : public BatteryProvider {
         void deinit() final;
         void loop() final;
         std::shared_ptr<BatteryStats> getStats() const final { return _stats; }
-        int usedHwUart() const final { return HwSerialPort; }
 
     private:
+        static char constexpr _serialPortOwner[] = "JK BMS";
+
+#ifdef JKBMS_DUMMY_SERIAL
+        std::unique_ptr<DummySerial> _upSerial;
+#else
+        std::unique_ptr<HardwareSerial> _upSerial;
+#endif
+
         enum class Status : unsigned {
             Initializing,
             Timeout,

--- a/include/JkBmsController.h
+++ b/include/JkBmsController.h
@@ -11,6 +11,8 @@ class DataPointContainer;
 
 namespace JkBms {
 
+uint8_t constexpr HwSerialPort = ((ARDUINO_USB_CDC_ON_BOOT != 1)?2:0);
+
 class Controller : public BatteryProvider {
     public:
         Controller() = default;
@@ -19,9 +21,7 @@ class Controller : public BatteryProvider {
         void deinit() final;
         void loop() final;
         std::shared_ptr<BatteryStats> getStats() const final { return _stats; }
-        bool usesHwPort2() const final {
-            return ARDUINO_USB_CDC_ON_BOOT != 1;
-        }
+        int usedHwUart() const final { return HwSerialPort; }
 
     private:
         enum class Status : unsigned {

--- a/include/PinMapping.h
+++ b/include/PinMapping.h
@@ -45,6 +45,8 @@ struct PinMapping_t {
     int8_t victron_rx;
     int8_t victron_tx2;
     int8_t victron_rx2;
+    int8_t victron_tx3;
+    int8_t victron_rx3;
     int8_t battery_rx;
     int8_t battery_rxen;
     int8_t battery_tx;

--- a/include/PowerMeter.h
+++ b/include/PowerMeter.h
@@ -60,6 +60,8 @@ private:
 
     mutable std::mutex _mutex;
 
+    static char constexpr _sdmSerialPortOwner[] = "SDM power meter";
+    std::unique_ptr<HardwareSerial> _upSdmSerial = nullptr;
     std::unique_ptr<SDM> _upSdm = nullptr;
     std::unique_ptr<SoftwareSerial> _upSmlSerial = nullptr;
 

--- a/include/SerialPortManager.h
+++ b/include/SerialPortManager.h
@@ -5,14 +5,16 @@
 
 class SerialPortManagerClass {
 public:
-    bool allocateMpptPort(int port);
-    bool allocateBatteryPort(int port);
+    void init();
+    bool allocateMpptPort(uint8_t port);
+    bool allocateBatteryPort(uint8_t port);
     void invalidateBatteryPort();
     void invalidateMpptPorts();
 
 private:
-    enum Owner {
-        BATTERY,
+    enum class Owner {
+        Console,
+        Battery,
         MPPT
     };
 

--- a/include/SerialPortManager.h
+++ b/include/SerialPortManager.h
@@ -1,29 +1,21 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #pragma once
 
-#include <map>
+#include <array>
+#include <optional>
+#include <string>
 
 class SerialPortManagerClass {
 public:
     void init();
-    bool allocateMpptPort(uint8_t port);
-    bool allocateBatteryPort(uint8_t port);
-    void invalidateBatteryPort();
-    void invalidateMpptPorts();
+
+    std::optional<uint8_t> allocatePort(std::string const& owner);
+    void freePort(std::string const& owner);
 
 private:
-    enum class Owner {
-        Console,
-        Battery,
-        MPPT
-    };
-
-    std::map<uint8_t, Owner> allocatedPorts;
-
-    bool allocatePort(uint8_t port, Owner owner);
-    void invalidate(Owner owner);
-
-    static const char* print(Owner owner);
+    // the amount of hardare UARTs available on supported ESP32 chips
+    static size_t constexpr _num_controllers = 3;
+    std::array<std::string, _num_controllers> _ports = { "" };
 };
 
 extern SerialPortManagerClass SerialPortManager;

--- a/include/VictronMppt.h
+++ b/include/VictronMppt.h
@@ -55,7 +55,8 @@ private:
     using controller_t = std::unique_ptr<VeDirectMpptController>;
     std::vector<controller_t> _controllers;
 
-    bool initController(int8_t rx, int8_t tx, bool logging, int hwSerialPort);
+    bool initController(int8_t rx, int8_t tx, bool logging,
+        uint8_t instance, uint8_t hwSerialPort);
 };
 
 extern VictronMpptClass VictronMppt;

--- a/include/VictronMppt.h
+++ b/include/VictronMppt.h
@@ -55,8 +55,9 @@ private:
     using controller_t = std::unique_ptr<VeDirectMpptController>;
     std::vector<controller_t> _controllers;
 
+    std::vector<String> _serialPortOwners;
     bool initController(int8_t rx, int8_t tx, bool logging,
-        uint8_t instance, uint8_t hwSerialPort);
+        uint8_t instance);
 };
 
 extern VictronMpptClass VictronMppt;

--- a/include/VictronSmartShunt.h
+++ b/include/VictronSmartShunt.h
@@ -9,11 +9,10 @@ public:
     void deinit() final { }
     void loop() final;
     std::shared_ptr<BatteryStats> getStats() const final { return _stats; }
-    bool usesHwPort2() const final {
-        return ARDUINO_USB_CDC_ON_BOOT != 1;
-    }
+    int usedHwUart() const final { return _hwSerialPort; }
 
 private:
+    static uint8_t constexpr _hwSerialPort = ((ARDUINO_USB_CDC_ON_BOOT != 1)?2:0);
     uint32_t _lastUpdate = 0;
     std::shared_ptr<VictronSmartShuntStats> _stats =
         std::make_shared<VictronSmartShuntStats>();

--- a/include/VictronSmartShunt.h
+++ b/include/VictronSmartShunt.h
@@ -6,13 +6,13 @@
 class VictronSmartShunt : public BatteryProvider {
 public:
     bool init(bool verboseLogging) final;
-    void deinit() final { }
+    void deinit() final;
     void loop() final;
     std::shared_ptr<BatteryStats> getStats() const final { return _stats; }
-    int usedHwUart() const final { return _hwSerialPort; }
 
 private:
-    static uint8_t constexpr _hwSerialPort = ((ARDUINO_USB_CDC_ON_BOOT != 1)?2:0);
+    static char constexpr _serialPortOwner[] = "SmartShunt";
+
     uint32_t _lastUpdate = 0;
     std::shared_ptr<VictronSmartShuntStats> _stats =
         std::make_shared<VictronSmartShuntStats>();

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -62,7 +62,8 @@ VeDirectFrameHandler<T>::VeDirectFrameHandler() :
 }
 
 template<typename T>
-void VeDirectFrameHandler<T>::init(char const* who, int8_t rx, int8_t tx, Print* msgOut, bool verboseLogging, uint16_t hwSerialPort)
+void VeDirectFrameHandler<T>::init(char const* who, int8_t rx, int8_t tx,
+		Print* msgOut, bool verboseLogging, uint8_t hwSerialPort)
 {
 	_vedirectSerial = std::make_unique<HardwareSerial>(hwSerialPort);
 	_vedirectSerial->end(); // make sure the UART will be re-initialized

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
@@ -30,7 +30,8 @@ public:
 
 protected:
     VeDirectFrameHandler();
-    void init(char const* who, int8_t rx, int8_t tx, Print* msgOut, bool verboseLogging, uint16_t hwSerialPort);
+    void init(char const* who, int8_t rx, int8_t tx, Print* msgOut,
+        bool verboseLogging, uint8_t hwSerialPort);
     virtual bool hexDataHandler(VeDirectHexData const &data) { return false; } // handles the disassembeled hex response
 
     bool _verboseLogging;

--- a/lib/VeDirectFrameHandler/VeDirectMpptController.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectMpptController.cpp
@@ -12,9 +12,11 @@
 
 //#define PROCESS_NETWORK_STATE
 
-void VeDirectMpptController::init(int8_t rx, int8_t tx, Print* msgOut, bool verboseLogging, uint16_t hwSerialPort)
+void VeDirectMpptController::init(int8_t rx, int8_t tx, Print* msgOut,
+		bool verboseLogging, uint8_t hwSerialPort)
 {
-	VeDirectFrameHandler::init("MPPT", rx, tx, msgOut, verboseLogging, hwSerialPort);
+	VeDirectFrameHandler::init("MPPT", rx, tx, msgOut,
+			verboseLogging, hwSerialPort);
 }
 
 bool VeDirectMpptController::processTextDataDerived(std::string const& name, std::string const& value)

--- a/lib/VeDirectFrameHandler/VeDirectMpptController.h
+++ b/lib/VeDirectFrameHandler/VeDirectMpptController.h
@@ -40,7 +40,8 @@ class VeDirectMpptController : public VeDirectFrameHandler<veMpptStruct> {
 public:
     VeDirectMpptController() = default;
 
-    void init(int8_t rx, int8_t tx, Print* msgOut, bool verboseLogging, uint16_t hwSerialPort);
+    void init(int8_t rx, int8_t tx, Print* msgOut,
+        bool verboseLogging, uint8_t hwSerialPort);
 
     using data_t = veMpptStruct;
 

--- a/lib/VeDirectFrameHandler/VeDirectShuntController.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectShuntController.cpp
@@ -3,10 +3,11 @@
 
 VeDirectShuntController VeDirectShunt;
 
-void VeDirectShuntController::init(int8_t rx, int8_t tx, Print* msgOut, bool verboseLogging)
+void VeDirectShuntController::init(int8_t rx, int8_t tx, Print* msgOut,
+		bool verboseLogging, uint8_t hwSerialPort)
 {
-	VeDirectFrameHandler::init("SmartShunt", rx, tx, msgOut, verboseLogging,
-			((ARDUINO_USB_CDC_ON_BOOT != 1)?2:0));
+	VeDirectFrameHandler::init("SmartShunt", rx, tx, msgOut,
+			verboseLogging, hwSerialPort);
 }
 
 bool VeDirectShuntController::processTextDataDerived(std::string const& name, std::string const& value)

--- a/lib/VeDirectFrameHandler/VeDirectShuntController.h
+++ b/lib/VeDirectFrameHandler/VeDirectShuntController.h
@@ -8,7 +8,8 @@ class VeDirectShuntController : public VeDirectFrameHandler<veShuntStruct> {
 public:
     VeDirectShuntController() = default;
 
-    void init(int8_t rx, int8_t tx, Print* msgOut, bool verboseLogging);
+    void init(int8_t rx, int8_t tx, Print* msgOut,
+        bool verboseLogging, uint8_t hwSerialPort);
 
     using data_t = veShuntStruct;
 

--- a/src/Battery.cpp
+++ b/src/Battery.cpp
@@ -5,7 +5,6 @@
 #include "JkBmsController.h"
 #include "VictronSmartShunt.h"
 #include "MqttBattery.h"
-#include "SerialPortManager.h"
 
 BatteryClass Battery;
 
@@ -39,7 +38,6 @@ void BatteryClass::updateSettings()
         _upProvider->deinit();
         _upProvider = nullptr;
     }
-    SerialPortManager.invalidateBatteryPort();
 
     CONFIG_T& config = Configuration.get();
     if (!config.Battery.Enabled) { return; }
@@ -64,18 +62,7 @@ void BatteryClass::updateSettings()
             return;
     }
 
-    // port is -1 if provider is neither JK BMS nor SmartShunt. otherwise, port
-    // is 2, unless running on ESP32-S3 with USB CDC, then port is 0.
-    int port = _upProvider->usedHwUart();
-    if (port >= 0 && !SerialPortManager.allocateBatteryPort(port)) {
-        _upProvider = nullptr;
-        return;
-    }
-
-    if (!_upProvider->init(verboseLogging)) {
-        SerialPortManager.invalidateBatteryPort();
-        _upProvider = nullptr;
-    }
+    if (!_upProvider->init(verboseLogging)) { _upProvider = nullptr; }
 }
 
 void BatteryClass::loop()

--- a/src/JkBmsController.cpp
+++ b/src/JkBmsController.cpp
@@ -7,6 +7,8 @@
 #include "JkBmsController.h"
 #include <frozen/map.h>
 
+namespace JkBms {
+
 //#define JKBMS_DUMMY_SERIAL
 
 #ifdef JKBMS_DUMMY_SERIAL
@@ -198,10 +200,8 @@ class DummySerial {
 };
 DummySerial HwSerial;
 #else
-HardwareSerial HwSerial((ARDUINO_USB_CDC_ON_BOOT != 1)?2:0);
+HardwareSerial HwSerial(HwSerialPort);
 #endif
-
-namespace JkBms {
 
 bool Controller::init(bool verboseLogging)
 {

--- a/src/PinMapping.cpp
+++ b/src/PinMapping.cpp
@@ -100,6 +100,14 @@
 #define VICTRON_PIN_RX2 -1
 #endif
 
+#ifndef VICTRON_PIN_TX3
+#define VICTRON_PIN_TX3 -1
+#endif
+
+#ifndef VICTRON_PIN_RX3
+#define VICTRON_PIN_RX3 -1
+#endif
+
 #ifndef BATTERY_PIN_RX
 #define BATTERY_PIN_RX -1
 #endif
@@ -207,8 +215,11 @@ PinMappingClass::PinMappingClass()
     _pinMapping.victron_rx = VICTRON_PIN_RX;
     _pinMapping.victron_tx = VICTRON_PIN_TX;
 
-    _pinMapping.victron_rx2 = VICTRON_PIN_RX;
-    _pinMapping.victron_tx2 = VICTRON_PIN_TX;
+    _pinMapping.victron_rx2 = VICTRON_PIN_RX2;
+    _pinMapping.victron_tx2 = VICTRON_PIN_TX2;
+
+    _pinMapping.victron_rx3 = VICTRON_PIN_RX3;
+    _pinMapping.victron_tx3 = VICTRON_PIN_TX3;
 
     _pinMapping.battery_rx = BATTERY_PIN_RX;
     _pinMapping.battery_rxen = BATTERY_PIN_RXEN;
@@ -292,6 +303,8 @@ bool PinMappingClass::init(const String& deviceMapping)
             _pinMapping.victron_tx = doc[i]["victron"]["tx"] | VICTRON_PIN_TX;
             _pinMapping.victron_rx2 = doc[i]["victron"]["rx2"] | VICTRON_PIN_RX2;
             _pinMapping.victron_tx2 = doc[i]["victron"]["tx2"] | VICTRON_PIN_TX2;
+            _pinMapping.victron_rx3 = doc[i]["victron"]["rx3"] | VICTRON_PIN_RX3;
+            _pinMapping.victron_tx3 = doc[i]["victron"]["tx3"] | VICTRON_PIN_TX3;
 
             _pinMapping.battery_rx = doc[i]["battery"]["rx"] | BATTERY_PIN_RX;
             _pinMapping.battery_rxen = doc[i]["battery"]["rxen"] | BATTERY_PIN_RXEN;

--- a/src/VictronSmartShunt.cpp
+++ b/src/VictronSmartShunt.cpp
@@ -3,7 +3,12 @@
 #include "Configuration.h"
 #include "PinMapping.h"
 #include "MessageOutput.h"
+#include "SerialPortManager.h"
 
+void VictronSmartShunt::deinit()
+{
+    SerialPortManager.freePort(_serialPortOwner);
+}
 
 bool VictronSmartShunt::init(bool verboseLogging)
 {
@@ -21,7 +26,10 @@ bool VictronSmartShunt::init(bool verboseLogging)
     auto tx = static_cast<gpio_num_t>(pin.battery_tx);
     auto rx = static_cast<gpio_num_t>(pin.battery_rx);
 
-    VeDirectShunt.init(rx, tx, &MessageOutput, verboseLogging, _hwSerialPort);
+    auto oHwSerialPort = SerialPortManager.allocatePort(_serialPortOwner);
+    if (!oHwSerialPort) { return false; }
+
+    VeDirectShunt.init(rx, tx, &MessageOutput, verboseLogging, *oHwSerialPort);
     return true;
 }
 

--- a/src/VictronSmartShunt.cpp
+++ b/src/VictronSmartShunt.cpp
@@ -21,7 +21,7 @@ bool VictronSmartShunt::init(bool verboseLogging)
     auto tx = static_cast<gpio_num_t>(pin.battery_tx);
     auto rx = static_cast<gpio_num_t>(pin.battery_rx);
 
-    VeDirectShunt.init(rx, tx, &MessageOutput, verboseLogging);
+    VeDirectShunt.init(rx, tx, &MessageOutput, verboseLogging, _hwSerialPort);
     return true;
 }
 

--- a/src/WebApi_device.cpp
+++ b/src/WebApi_device.cpp
@@ -91,6 +91,8 @@ void WebApiDeviceClass::onDeviceAdminGet(AsyncWebServerRequest* request)
     victronPinObj["tx"] = pin.victron_tx;
     victronPinObj["rx2"] = pin.victron_rx2;
     victronPinObj["tx2"] = pin.victron_tx2;
+    victronPinObj["rx3"] = pin.victron_rx3;
+    victronPinObj["tx3"] = pin.victron_tx3;
 
     auto batteryPinObj = curPin["battery"].to<JsonObject>();
     batteryPinObj["rx"] = pin.battery_rx;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "InverterSettings.h"
 #include "Led_Single.h"
 #include "MessageOutput.h"
+#include "SerialPortManager.h"
 #include "VictronMppt.h"
 #include "Battery.h"
 #include "Huawei_can.h"
@@ -95,6 +96,8 @@ void setup()
     }
     const auto& pin = PinMapping.get();
     MessageOutput.println("done");
+
+    SerialPortManager.init();
 
     // Initialize WiFi
     MessageOutput.print("Initialize Network... ");


### PR DESCRIPTION
Still not using software based serial, this change makes the serial port manager assign a hardware serial port on a first-come-first-serve basis. All software components requiring a serial port now ask for the index to use at the serial port manager. There may be none left, such that a meaningful message is printed:

```
[SerialPortManager] HW UART 0 already in use by 'Victron MPPT 1'
[SerialPortManager] HW UART 1 already in use by 'Victron MPPT 2'
[SerialPortManager] HW UART 2 already in use by 'SDM power meter'
[SerialPortManager] Cannot assign another HW UART port to 'JK BMS'
```

ESP32 without USB CDC (all non-S3 and ESP32-S3 withouth USB CDC) still print their serial messages through hardware UART 0, so that one is reserved at initialization and only two hardware UARTs are freely available:

```
[SerialPortManager] HW UART port 0 now in use by 'Serial Console'
...
[SerialPortManager] HW UART 0 already in use by 'Serial Console'
[SerialPortManager] HW UART 1 already in use by 'Victron MPPT 1'
[SerialPortManager] HW UART 2 now in use by 'JK BMS'
```

In particular, this allows to connect up to three Victron MPPT, which was the original motivation for this PR.

```
[SerialPortManager] HW UART 0 already in use by 'Victron MPPT 1'
[SerialPortManager] HW UART 1 already in use by 'Victron MPPT 2'
[SerialPortManager] HW UART 2 already in use by 'Victron MPPT 3'
[SerialPortManager] Cannot assign another HW UART port to 'JK BMS'
```