### PR TITLE
Set/obtain DPL target power consumption via MQTT

### DIFF
--- a/include/MqttHandlePowerLimiter.h
+++ b/include/MqttHandlePowerLimiter.h
@@ -24,7 +24,8 @@ private:
         VoltageStopThreshold,
         FullSolarPassThroughStartVoltage,
         FullSolarPassThroughStopVoltage,
-        UpperPowerLimit
+        UpperPowerLimit,
+        TargetPowerConsumption
     };
 
     void onMqttCmd(MqttPowerLimiterCommand command, const espMqttClientTypes::MessageProperties& properties, const char* topic, const uint8_t* payload, size_t len, size_t index, size_t total);

--- a/src/MqttHandlePowerLimiter.cpp
+++ b/src/MqttHandlePowerLimiter.cpp
@@ -45,6 +45,7 @@ void MqttHandlePowerLimiterClass::init(Scheduler& scheduler)
     subscribe("threshold/voltage/full_solar_passthrough_stop", MqttPowerLimiterCommand::FullSolarPassThroughStopVoltage);
     subscribe("mode", MqttPowerLimiterCommand::Mode);
     subscribe("upper_power_limit", MqttPowerLimiterCommand::UpperPowerLimit);
+    subscribe("target_power_consumption", MqttPowerLimiterCommand::TargetPowerConsumption);
 
     _lastPublish = millis();
 }
@@ -78,6 +79,8 @@ void MqttHandlePowerLimiterClass::loop()
     MqttSettings.publish("powerlimiter/status/mode", String(val));
     
     MqttSettings.publish("powerlimiter/status/upper_power_limit", String(config.PowerLimiter.UpperPowerLimit));
+
+    MqttSettings.publish("powerlimiter/status/target_power_consumption", String(config.PowerLimiter.TargetPowerConsumption));
 
     MqttSettings.publish("powerlimiter/status/inverter_update_timeouts", String(PowerLimiter.getInverterUpdateTimeouts()));
 
@@ -181,6 +184,11 @@ void MqttHandlePowerLimiterClass::onMqttCmd(MqttPowerLimiterCommand command, con
             if (config.PowerLimiter.UpperPowerLimit == intValue) { return; }
             MessageOutput.printf("Setting upper power limit to: %d W\r\n", intValue);
             config.PowerLimiter.UpperPowerLimit = intValue;
+            break;
+        case MqttPowerLimiterCommand::TargetPowerConsumption:
+            if (config.PowerLimiter.TargetPowerConsumption == intValue) { return; }
+            MessageOutput.printf("Setting target power consumption to: %d W\r\n", intValue);
+            config.PowerLimiter.TargetPowerConsumption = intValue;
             break;
     }
 


### PR DESCRIPTION
As suggested in https://github.com/helgeerbe/OpenDTU-OnBattery/pull/1047#issuecomment-2170469378 TargetPowerConsumption can be set by sending a power value to topic 'powerlimiter/cmd/target_power_consumption' via MQTT and be read from topic 'powerlimiter/status/target_power_consumption'.

Is it correct that changing config values by issuing MQTT commands still entails writing to the flash memory (and thereby increasing the 'config save count')? 
A development goal is to keep and reflect (at some other place than the DPL settings menu) these changes independent of the flashed values?
