### PR TITLE
Improvement: Double the VE.Direct receive buffer to 512 bytes to avoid overflow

### DIFF
--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -66,6 +66,7 @@ void VeDirectFrameHandler<T>::init(char const* who, int8_t rx, int8_t tx,
 		Print* msgOut, bool verboseLogging, uint8_t hwSerialPort)
 {
 	_vedirectSerial = std::make_unique<HardwareSerial>(hwSerialPort);
+	_vedirectSerial->setRxBufferSize(512); // increased from default (256) to 512 Byte to avoid overflow
 	_vedirectSerial->end(); // make sure the UART will be re-initialized
 	_vedirectSerial->begin(19200, SERIAL_8N1, rx, tx);
 	_vedirectSerial->flush();


### PR DESCRIPTION
Maximum buffer fill level when entering the VeDirectFrameHandler::loop()
Buffer size 256 Byte: 256 bytes 
Buffer size 512 Byte: 344 bytes  (maximum value, logged after 4 days)
