### PR TITLE
Fix an issue if not all configured MPPTs delivers valid Data

### DIFF
--- a/src/VictronMppt.cpp
+++ b/src/VictronMppt.cpp
@@ -75,12 +75,16 @@ void VictronMpptClass::loop()
     }
 }
 
+/*
+ * isDataValid()
+ * return: true = if at least one of the MPPT controllers delivers valid data
+ */
 bool VictronMpptClass::isDataValid() const
 {
     std::lock_guard<std::mutex> lock(_mutex);
 
     for (auto const& upController: _controllers) {
-        if (!upController->isDataValid()) { return false; }
+        if (upController->isDataValid()) { return true; }
     }
 
     return !_controllers.empty();


### PR DESCRIPTION
Hallo @schlimmchen ,
in #975  wurde noch ein Problem entdeckt wenn mehrere Victron MPPTs konfiguriert wurden, aber mindestens einer keine Daten über die VE.Direct Schnittstelle sendet.

Das Problem ergibt sich aus der Kombination der Funktion VictronMpptClass::isDataValid() und einer weiteren wie VictronMpptClass::getOutputVoltage()

Die VictronMpptClass::getOutputVoltage()
liefert den kleinsten Wert aus der Menge an MPPTs die gültige Daten senden.

Die VictronMpptClass::isDataValid()
liefert nur true wenn **alle** konfigurierten MPPTs gültige Daten liefern.

Und wenn man das wie in der Funktion PowerLimiterClass::getBatteryVoltage() kombiniert 
float chargeControllerVoltage = -1;
    if (VictronMppt.isDataValid()) {
        res = chargeControllerVoltage = static_cast<float>(VictronMppt.getOutputVoltage());
    }
Dann ist das Ergebnis immer -1 wenn ein MPPT ausfällt.

Dieser PR sollte das Problem beheben. Ich bin mir nicht sicher ob die aktuelle Logik
nicht aus Gründen die ich nicht kenne absichtlich so geplant war. 
Ich finde 3 Stellen im Code wo VictronMpptClass::isDataValid() verwendet wird und an keiner der 3 Stellen sehe ich ein Problem wenn wir die Logik umdrehen.