### PR TITLE
Fix DPL nighttime discharging

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -74,6 +74,7 @@ private:
     Mode _mode = Mode::Normal;
     std::shared_ptr<InverterAbstract> _inverter = nullptr;
     bool _batteryDischargeEnabled = false;
+    bool _nighttimeDischarging = false;
     uint32_t _nextInverterRestart = 0; // Values: 0->not calculated / 1->no restart configured / >1->time of next inverter restart in millis()
     uint32_t _nextCalculateCheck = 5000; // time in millis for next NTP check to calulate restart
     bool _fullSolarPassThroughEnabled = false;

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -240,8 +240,7 @@ void PowerLimiterClass::loop()
     auto getBatteryPower = [this,&config]() -> bool {
         if (config.PowerLimiter.IsInverterSolarPowered) { return false; }
 
-        auto isDayPeriod = (SunPosition.isSunsetAvailable() && SunPosition.isDayPeriod())
-            || getSolarPower() > 0;
+        auto isDayPeriod = SunPosition.isSunsetAvailable() ? SunPosition.isDayPeriod() : getSolarPower() > 0;
 
         if (_nighttimeDischarging && isDayPeriod) {
             _nighttimeDischarging = false;


### PR DESCRIPTION
the switch "always start discharging battery at night" would cause to stop discharging the battery when there was solar power and the battery was discharged below the start threshold.

this change introduces a nighttime discharging boolean variable, which is enabled the instant we decide to start a battery discharge cycle due to nighttime havin arrived. we reset this variable as soon as it is daytime (solar power available). in that case, we allow discharging the battery if the start threshold was reached. this can actually be the case if the battery is charged with cheap electricity during the night.

removed comments as they merely spell out what the if statement already expresses quite nicely.

closes #1123.