### PR TITLE
improvement: show battery voltage and power in live view

### DIFF
--- a/include/BatteryStats.h
+++ b/include/BatteryStats.h
@@ -20,11 +20,13 @@ class BatteryStats {
 
         uint8_t getSoC() const { return _soc; }
         uint32_t getSoCAgeSeconds() const { return (millis() - _lastUpdateSoC) / 1000; }
+        uint8_t getSoCPrecision() const { return _socPrecision; }
 
         float getVoltage() const { return _voltage; }
         uint32_t getVoltageAgeSeconds() const { return (millis() - _lastUpdateVoltage) / 1000; }
 
         float getChargeCurrent() const { return _current; };
+        uint8_t getChargeCurrentPrecision() const { return _currentPrecision; }
 
         // convert stats to JSON for web application live view
         virtual void getLiveViewData(JsonVariant& root) const;

--- a/include/BatteryStats.h
+++ b/include/BatteryStats.h
@@ -14,7 +14,7 @@ class BatteryStats {
     public:
         String const& getManufacturer() const { return _manufacturer; }
 
-        // the last time *any* datum was updated
+        // the last time *any* data was updated
         uint32_t getAgeSeconds() const { return (millis() - _lastUpdate) / 1000; }
         bool updateAvailable(uint32_t since) const;
 
@@ -31,7 +31,7 @@ class BatteryStats {
 
         void mqttLoop();
 
-        // the interval at which all battery datums will be re-published, even
+        // the interval at which all battery data will be re-published, even
         // if they did not change. used to calculate Home Assistent expiration.
         virtual uint32_t getMqttFullPublishIntervalMs() const;
 
@@ -59,8 +59,9 @@ class BatteryStats {
             _lastUpdateVoltage = _lastUpdate = timestamp;
         }
 
-        void setCurrent(float current, uint32_t timestamp) {
+        void setCurrent(float current, uint8_t precision, uint32_t timestamp) {
             _current = current;
+            _currentPrecision = precision;
             _lastUpdateCurrent = _lastUpdate = timestamp;
         }
 
@@ -81,6 +82,7 @@ class BatteryStats {
         // total current into (positive) or from (negative)
         // the battery, i.e., the charging current
         float _current = 0;
+        uint8_t _currentPrecision = 0; // decimal places
         uint32_t _lastUpdateCurrent = 0;
 };
 
@@ -262,7 +264,7 @@ class MqttBatteryStats : public BatteryStats {
         // we do NOT publish the same data under a different topic.
         void mqttPublish() const final { }
 
-        // if the voltage is subscribed to at all, it alone does not warrant a
-        // card in the live view, since the SoC and voltage is already displayed at the top
+        // we don't need a card in the liveview, since the SoC and
+        // voltage (if available) is already displayed at the top.
         void getLiveViewData(JsonVariant& root) const final { }
 };

--- a/src/BatteryStats.cpp
+++ b/src/BatteryStats.cpp
@@ -78,6 +78,7 @@ void BatteryStats::getLiveViewData(JsonVariant& root) const
 
     addLiveViewValue(root, "SoC", _soc, "%", _socPrecision);
     addLiveViewValue(root, "voltage", _voltage, "V", 2);
+    addLiveViewValue(root, "current", _current, "A", 1);
 }
 
 void PylontechBatteryStats::getLiveViewData(JsonVariant& root) const
@@ -89,7 +90,6 @@ void PylontechBatteryStats::getLiveViewData(JsonVariant& root) const
     addLiveViewValue(root, "chargeCurrentLimitation", _chargeCurrentLimitation, "A", 1);
     addLiveViewValue(root, "dischargeCurrentLimitation", _dischargeCurrentLimitation, "A", 1);
     addLiveViewValue(root, "stateOfHealth", _stateOfHealth, "%", 0);
-    addLiveViewValue(root, "current", _current, "A", 1);
     addLiveViewValue(root, "temperature", _temperature, "°C", 1);
 
     addLiveViewTextValue(root, "chargeEnabled", (_chargeEnabled?"yes":"no"));
@@ -124,7 +124,6 @@ void PytesBatteryStats::getLiveViewData(JsonVariant& root) const
     BatteryStats::getLiveViewData(root);
 
     // values go into the "Status" card of the web application
-    addLiveViewValue(root, "current", _current, "A", 1);
     addLiveViewValue(root, "chargeVoltage", _chargeVoltageLimit, "V", 1);
     addLiveViewValue(root, "chargeCurrentLimitation", _chargeCurrentLimit, "A", 1);
     addLiveViewValue(root, "dischargeVoltageLimitation", _dischargeVoltageLimit, "V", 1);
@@ -198,11 +197,6 @@ void JkBmsBatteryStats::getJsonData(JsonVariant& root, bool verbose) const
     using Label = JkBms::DataPointLabel;
 
     auto oCurrent = _dataPoints.get<Label::BatteryCurrentMilliAmps>();
-    if (oCurrent.has_value()) {
-        addLiveViewValue(root, "current",
-                static_cast<float>(*oCurrent) / 1000, "A", 2);
-    }
-
     auto oVoltage = _dataPoints.get<Label::BatteryVoltageMilliVolt>();
     if (oVoltage.has_value() && oCurrent.has_value()) {
         auto current = static_cast<float>(*oCurrent) / 1000;
@@ -306,6 +300,7 @@ void BatteryStats::mqttPublish() const
     MqttSettings.publish("battery/dataAge", String(getAgeSeconds()));
     MqttSettings.publish("battery/stateOfCharge", String(_soc));
     MqttSettings.publish("battery/voltage", String(_voltage));
+    MqttSettings.publish("battery/current", String(_current));
 }
 
 void PylontechBatteryStats::mqttPublish() const
@@ -316,7 +311,6 @@ void PylontechBatteryStats::mqttPublish() const
     MqttSettings.publish("battery/settings/chargeCurrentLimitation", String(_chargeCurrentLimitation));
     MqttSettings.publish("battery/settings/dischargeCurrentLimitation", String(_dischargeCurrentLimitation));
     MqttSettings.publish("battery/stateOfHealth", String(_stateOfHealth));
-    MqttSettings.publish("battery/current", String(_current));
     MqttSettings.publish("battery/temperature", String(_temperature));
     MqttSettings.publish("battery/alarm/overCurrentDischarge", String(_alarmOverCurrentDischarge));
     MqttSettings.publish("battery/alarm/overCurrentCharge", String(_alarmOverCurrentCharge));
@@ -347,7 +341,6 @@ void PytesBatteryStats::mqttPublish() const
     MqttSettings.publish("battery/settings/dischargeVoltageLimitation", String(_dischargeVoltageLimit));
 
     MqttSettings.publish("battery/stateOfHealth", String(_stateOfHealth));
-    MqttSettings.publish("battery/current", String(_current));
     MqttSettings.publish("battery/temperature", String(_temperature));
 
     if (_chargedEnergy != -1) {
@@ -505,6 +498,13 @@ void JkBmsBatteryStats::updateFrom(JkBms::DataPointContainer const& dp)
                 oVoltageDataPoint->getTimestamp());
     }
 
+    auto oCurrent = dp.get<Label::BatteryCurrentMilliAmps>();
+    if (oCurrent.has_value()) {
+        auto oCurrentDataPoint = dp.getDataPointFor<Label::BatteryCurrentMilliAmps>();
+        BatteryStats::setCurrent(static_cast<float>(*oCurrent) / 1000,
+                oCurrentDataPoint->getTimestamp());
+    }
+
     _dataPoints.updateFrom(dp);
 
     auto oCellVoltages = _dataPoints.get<Label::CellsMilliVolt>();
@@ -545,9 +545,9 @@ void JkBmsBatteryStats::updateFrom(JkBms::DataPointContainer const& dp)
 void VictronSmartShuntStats::updateFrom(VeDirectShuntController::data_t const& shuntData) {
     BatteryStats::setVoltage(shuntData.batteryVoltage_V_mV / 1000.0, millis());
     BatteryStats::setSoC(static_cast<float>(shuntData.SOC) / 10, 1/*precision*/, millis());
+    BatteryStats::setCurrent(static_cast<float>(shuntData.batteryCurrent_I_mA) / 1000, millis());
     _fwversion = shuntData.getFwVersionFormatted();
 
-    _current = static_cast<float>(shuntData.batteryCurrent_I_mA) / 1000;
     _chargeCycles = shuntData.H4;
     _timeToGo = shuntData.TTG / 60;
     _chargedEnergy = static_cast<float>(shuntData.H18) / 100;
@@ -574,7 +574,6 @@ void VictronSmartShuntStats::getLiveViewData(JsonVariant& root) const {
     BatteryStats::getLiveViewData(root);
 
     // values go into the "Status" card of the web application
-    addLiveViewValue(root, "current", _current, "A", 1);
     addLiveViewValue(root, "chargeCycles", _chargeCycles, "", 0);
     addLiveViewValue(root, "chargedEnergy", _chargedEnergy, "kWh", 2);
     addLiveViewValue(root, "dischargedEnergy", _dischargedEnergy, "kWh", 2);
@@ -597,7 +596,6 @@ void VictronSmartShuntStats::getLiveViewData(JsonVariant& root) const {
 void VictronSmartShuntStats::mqttPublish() const {
     BatteryStats::mqttPublish();
 
-    MqttSettings.publish("battery/current", String(_current));
     MqttSettings.publish("battery/chargeCycles", String(_chargeCycles));
     MqttSettings.publish("battery/chargedEnergy", String(_chargedEnergy));
     MqttSettings.publish("battery/dischargedEnergy", String(_dischargedEnergy));

--- a/src/BatteryStats.cpp
+++ b/src/BatteryStats.cpp
@@ -78,7 +78,7 @@ void BatteryStats::getLiveViewData(JsonVariant& root) const
 
     addLiveViewValue(root, "SoC", _soc, "%", _socPrecision);
     addLiveViewValue(root, "voltage", _voltage, "V", 2);
-    addLiveViewValue(root, "current", _current, "A", 1);
+    addLiveViewValue(root, "current", _current, "A", _currentPrecision);
 }
 
 void PylontechBatteryStats::getLiveViewData(JsonVariant& root) const
@@ -501,7 +501,7 @@ void JkBmsBatteryStats::updateFrom(JkBms::DataPointContainer const& dp)
     auto oCurrent = dp.get<Label::BatteryCurrentMilliAmps>();
     if (oCurrent.has_value()) {
         auto oCurrentDataPoint = dp.getDataPointFor<Label::BatteryCurrentMilliAmps>();
-        BatteryStats::setCurrent(static_cast<float>(*oCurrent) / 1000,
+        BatteryStats::setCurrent(static_cast<float>(*oCurrent) / 1000, 2/*precision*/,
                 oCurrentDataPoint->getTimestamp());
     }
 
@@ -545,7 +545,7 @@ void JkBmsBatteryStats::updateFrom(JkBms::DataPointContainer const& dp)
 void VictronSmartShuntStats::updateFrom(VeDirectShuntController::data_t const& shuntData) {
     BatteryStats::setVoltage(shuntData.batteryVoltage_V_mV / 1000.0, millis());
     BatteryStats::setSoC(static_cast<float>(shuntData.SOC) / 10, 1/*precision*/, millis());
-    BatteryStats::setCurrent(static_cast<float>(shuntData.batteryCurrent_I_mA) / 1000, millis());
+    BatteryStats::setCurrent(static_cast<float>(shuntData.batteryCurrent_I_mA) / 1000, 2/*precision*/, millis());
     _fwversion = shuntData.getFwVersionFormatted();
 
     _chargeCycles = shuntData.H4;

--- a/src/BatteryStats.cpp
+++ b/src/BatteryStats.cpp
@@ -298,9 +298,15 @@ void BatteryStats::mqttPublish() const
 {
     MqttSettings.publish("battery/manufacturer", _manufacturer);
     MqttSettings.publish("battery/dataAge", String(getAgeSeconds()));
-    MqttSettings.publish("battery/stateOfCharge", String(_soc));
-    MqttSettings.publish("battery/voltage", String(_voltage));
-    MqttSettings.publish("battery/current", String(_current));
+    if (isSoCValid()) {
+        MqttSettings.publish("battery/stateOfCharge", String(_soc));
+    }
+    if (isVoltageValid()) {
+        MqttSettings.publish("battery/voltage", String(_voltage));
+    }
+    if (isCurrentValid()) {
+        MqttSettings.publish("battery/current", String(_current));
+    }
 }
 
 void PylontechBatteryStats::mqttPublish() const

--- a/src/PylontechCanReceiver.cpp
+++ b/src/PylontechCanReceiver.cpp
@@ -39,12 +39,12 @@ void PylontechCanReceiver::onMessage(twai_message_t rx_message)
 
         case 0x356: {
             _stats->setVoltage(this->scaleValue(this->readSignedInt16(rx_message.data), 0.01), millis());
-            _stats->_current = this->scaleValue(this->readSignedInt16(rx_message.data + 2), 0.1);
+            _stats->setCurrent(this->scaleValue(this->readSignedInt16(rx_message.data + 2), 0.1), millis());
             _stats->_temperature = this->scaleValue(this->readSignedInt16(rx_message.data + 4), 0.1);
 
             if (_verboseLogging) {
                 MessageOutput.printf("[Pylontech] voltage: %f current: %f temperature: %f\r\n",
-                        _stats->getVoltage(), _stats->_current, _stats->_temperature);
+                        _stats->getVoltage(), _stats->getChargeCurrent(), _stats->_temperature);
             }
             break;
         }
@@ -157,7 +157,7 @@ void PylontechCanReceiver::dummyData()
     _stats->_dischargeCurrentLimitation = dummyFloat(12);
     _stats->_stateOfHealth = 99;
     _stats->setVoltage(48.67, millis());
-    _stats->_current = dummyFloat(-1);
+    _stats->setCurrent(dummyFloat(-1), millis());
     _stats->_temperature = dummyFloat(20);
 
     _stats->_chargeEnabled = true;

--- a/src/PylontechCanReceiver.cpp
+++ b/src/PylontechCanReceiver.cpp
@@ -39,7 +39,7 @@ void PylontechCanReceiver::onMessage(twai_message_t rx_message)
 
         case 0x356: {
             _stats->setVoltage(this->scaleValue(this->readSignedInt16(rx_message.data), 0.01), millis());
-            _stats->setCurrent(this->scaleValue(this->readSignedInt16(rx_message.data + 2), 0.1), millis());
+            _stats->setCurrent(this->scaleValue(this->readSignedInt16(rx_message.data + 2), 0.1), 1/*precision*/, millis());
             _stats->_temperature = this->scaleValue(this->readSignedInt16(rx_message.data + 4), 0.1);
 
             if (_verboseLogging) {
@@ -157,7 +157,7 @@ void PylontechCanReceiver::dummyData()
     _stats->_dischargeCurrentLimitation = dummyFloat(12);
     _stats->_stateOfHealth = 99;
     _stats->setVoltage(48.67, millis());
-    _stats->setCurrent(dummyFloat(-1), millis());
+    _stats->setCurrent(dummyFloat(-1), 1/*precision*/, millis());
     _stats->_temperature = dummyFloat(20);
 
     _stats->_chargeEnabled = true;

--- a/src/PytesCanReceiver.cpp
+++ b/src/PytesCanReceiver.cpp
@@ -40,7 +40,7 @@ void PytesCanReceiver::onMessage(twai_message_t rx_message)
 
         case 0x356: {
             _stats->setVoltage(this->scaleValue(this->readSignedInt16(rx_message.data), 0.01), millis());
-            _stats->setCurrent(this->scaleValue(this->readSignedInt16(rx_message.data + 2), 0.1), millis());
+            _stats->setCurrent(this->scaleValue(this->readSignedInt16(rx_message.data + 2), 0.1), 1/*precision*/, millis());
             _stats->_temperature = this->scaleValue(this->readSignedInt16(rx_message.data + 4), 0.1);
 
             if (_verboseLogging) {

--- a/src/PytesCanReceiver.cpp
+++ b/src/PytesCanReceiver.cpp
@@ -40,12 +40,12 @@ void PytesCanReceiver::onMessage(twai_message_t rx_message)
 
         case 0x356: {
             _stats->setVoltage(this->scaleValue(this->readSignedInt16(rx_message.data), 0.01), millis());
-            _stats->_current = this->scaleValue(this->readSignedInt16(rx_message.data + 2), 0.1);
+            _stats->setCurrent(this->scaleValue(this->readSignedInt16(rx_message.data + 2), 0.1), millis());
             _stats->_temperature = this->scaleValue(this->readSignedInt16(rx_message.data + 4), 0.1);
 
             if (_verboseLogging) {
                 MessageOutput.printf("[Pytes] voltage: %f current: %f temperature: %f\r\n",
-                        _stats->getVoltage(), _stats->_current, _stats->_temperature);
+                        _stats->getVoltage(), _stats->getChargeCurrent(), _stats->_temperature);
             }
             break;
         }

--- a/src/WebApi_ws_live.cpp
+++ b/src/WebApi_ws_live.cpp
@@ -93,7 +93,7 @@ void WebApiWsLiveClass::generateOnBatteryJsonResponse(JsonVariant& root, bool al
 
         if (config.Battery.Enabled) {
             if (spStats->isSoCValid()) {
-                addTotalField(batteryObj, "soc", spStats->getSoC(), "%", 0);
+                addTotalField(batteryObj, "soc", spStats->getSoC(), "%", spStats->getSoCPrecision());
             }
 
             if (spStats->isVoltageValid()) {
@@ -101,7 +101,7 @@ void WebApiWsLiveClass::generateOnBatteryJsonResponse(JsonVariant& root, bool al
             }
 
             if (spStats->isCurrentValid()) {
-                addTotalField(batteryObj, "current", spStats->getChargeCurrent(), "A", 1);
+                addTotalField(batteryObj, "current", spStats->getChargeCurrent(), "A", spStats->getChargeCurrentPrecision());
             }
 
             if (spStats->isVoltageValid() && spStats->isCurrentValid()) {

--- a/src/WebApi_ws_live.cpp
+++ b/src/WebApi_ws_live.cpp
@@ -92,7 +92,17 @@ void WebApiWsLiveClass::generateOnBatteryJsonResponse(JsonVariant& root, bool al
         batteryObj["enabled"] = config.Battery.Enabled;
 
         if (config.Battery.Enabled) {
-            addTotalField(batteryObj, "soc", spStats->getSoC(), "%", 0);
+            if (spStats->isSoCValid()) {
+                addTotalField(batteryObj, "soc", spStats->getSoC(), "%", 0);
+            }
+
+            if (spStats->isVoltageValid()) {
+                addTotalField(batteryObj, "voltage", spStats->getVoltage(), "V", 2);
+
+                if (spStats->isCurrentValid()) {
+                   addTotalField(batteryObj, "power", spStats->getVoltage() * spStats->getChargeCurrent(), "W", 1);
+                }
+            }
         }
 
         if (!all) { _lastPublishBattery = millis(); }

--- a/src/WebApi_ws_live.cpp
+++ b/src/WebApi_ws_live.cpp
@@ -98,10 +98,14 @@ void WebApiWsLiveClass::generateOnBatteryJsonResponse(JsonVariant& root, bool al
 
             if (spStats->isVoltageValid()) {
                 addTotalField(batteryObj, "voltage", spStats->getVoltage(), "V", 2);
+            }
 
-                if (spStats->isCurrentValid()) {
-                   addTotalField(batteryObj, "power", spStats->getVoltage() * spStats->getChargeCurrent(), "W", 1);
-                }
+            if (spStats->isCurrentValid()) {
+                addTotalField(batteryObj, "current", spStats->getChargeCurrent(), "A", 1);
+            }
+
+            if (spStats->isVoltageValid() && spStats->isCurrentValid()) {
+                addTotalField(batteryObj, "power", spStats->getVoltage() * spStats->getChargeCurrent(), "W", 1);
             }
         }
 

--- a/webapp/src/components/CardElement.vue
+++ b/webapp/src/components/CardElement.vue
@@ -1,7 +1,7 @@
 <template>
     <div :class="['card', addSpace ? 'mt-5' : '' ]">
         <div :class="['card-header', textVariant]">{{ text }}</div>
-        <div :class="['card-body', 'card-text', centerContent ? 'text-center' : '', flexChildern ? 'd-flex' : '']">
+        <div :class="['card-body', 'card-text', centerContent ? 'text-center' : '', flexChildren ? 'd-flex' : '']">
             <slot />
         </div>
     </div>
@@ -16,7 +16,7 @@ export default defineComponent({
         'textVariant': String,
         'addSpace': Boolean,
         'centerContent': Boolean,
-        'flexChildern': Boolean,
+        'flexChildren': Boolean,
     },
 });
 </script>

--- a/webapp/src/components/CardElement.vue
+++ b/webapp/src/components/CardElement.vue
@@ -1,7 +1,7 @@
 <template>
     <div :class="['card', addSpace ? 'mt-5' : '' ]">
         <div :class="['card-header', textVariant]">{{ text }}</div>
-        <div :class="['card-body', 'card-text', centerContent ? 'text-center' : '']">
+        <div :class="['card-body', 'card-text', centerContent ? 'text-center' : '', flexChildern ? 'd-flex' : '']">
             <slot />
         </div>
     </div>
@@ -16,6 +16,7 @@ export default defineComponent({
         'textVariant': String,
         'addSpace': Boolean,
         'centerContent': Boolean,
+        'flexChildern': Boolean,
     },
 });
 </script>

--- a/webapp/src/components/InverterTotalInfo.vue
+++ b/webapp/src/components/InverterTotalInfo.vue
@@ -67,13 +67,39 @@
             </CardElement>
         </div>
         <div class="col" v-if="totalBattData.enabled">
-            <CardElement centerContent textVariant="text-bg-success" :text="$t('invertertotalinfo.BatterySoc')">
+            <CardElement centerContent textVariant="text-bg-success" :text="$t('invertertotalinfo.Battery')">
                 <h2>
-                    {{ $n(totalBattData.soc.v, 'decimal', {
-                        minimumFractionDigits: totalBattData.soc.d,
-                        maximumFractionDigits: totalBattData.soc.d
-                    }) }}
-                    <small class="text-muted">{{ totalBattData.soc.u }}</small>
+                    <template v-if="totalBattData.soc">
+                        {{ $n(totalBattData.soc.v, 'decimal', {
+                            minimumFractionDigits: totalBattData.soc.d,
+                            maximumFractionDigits: totalBattData.soc.d
+                        }) }}
+                        <small class="text-muted">{{ totalBattData.soc.u }}</small>
+                    </template>
+
+                    <template v-if="totalBattData.soc && totalBattData.voltage">
+                        /
+                    </template>
+
+                    <template v-if="totalBattData.voltage">
+                        {{ $n(totalBattData.voltage.v, 'decimal', {
+                            minimumFractionDigits: totalBattData.voltage.d,
+                            maximumFractionDigits: totalBattData.voltage.d
+                        }) }}
+                        <small class="text-muted">{{ totalBattData.voltage.u }}</small>
+                    </template>
+
+                    <template v-if="totalBattData.power">
+                        /
+                    </template>
+
+                    <template v-if="totalBattData.power">
+                        {{ $n(totalBattData.power.v, 'decimal', {
+                            minimumFractionDigits: totalBattData.power.d,
+                            maximumFractionDigits: totalBattData.power.d
+                        }) }}
+                        <small class="text-muted">{{ totalBattData.power.u }}</small>
+                    </template>
                 </h2>
             </CardElement>
         </div>

--- a/webapp/src/components/InverterTotalInfo.vue
+++ b/webapp/src/components/InverterTotalInfo.vue
@@ -66,43 +66,54 @@
                 </h2>
             </CardElement>
         </div>
-        <div class="col" v-if="totalBattData.enabled">
-            <CardElement centerContent textVariant="text-bg-success" :text="$t('invertertotalinfo.Battery')">
-                <h2>
-                    <template v-if="totalBattData.soc">
-                        {{ $n(totalBattData.soc.v, 'decimal', {
-                            minimumFractionDigits: totalBattData.soc.d,
-                            maximumFractionDigits: totalBattData.soc.d
-                        }) }}
-                        <small class="text-muted">{{ totalBattData.soc.u }}</small>
-                    </template>
+        <template v-if="totalBattData.enabled">
+            <div class="col">
+                <CardElement centerContent flexChildern textVariant="text-bg-success" :text="$t('invertertotalinfo.BatteryCharge')">
+                    <div class="flex-fill" v-if="totalBattData.soc">
+                        <h2>
+                            {{ $n(totalBattData.soc.v, 'decimal', {
+                                minimumFractionDigits: totalBattData.soc.d,
+                                maximumFractionDigits: totalBattData.soc.d
+                            }) }}
+                            <small class="text-muted">{{ totalBattData.soc.u }}</small>
+                        </h2>
+                    </div>
 
-                    <template v-if="totalBattData.soc && totalBattData.voltage">
-                        /
-                    </template>
+                    <div class="flex-fill" v-if="totalBattData.voltage">
+                        <h2>
+                            {{ $n(totalBattData.voltage.v, 'decimal', {
+                                minimumFractionDigits: totalBattData.voltage.d,
+                                maximumFractionDigits: totalBattData.voltage.d
+                            }) }}
+                            <small class="text-muted">{{ totalBattData.voltage.u }}</small>
+                        </h2>
+                    </div>
+                </CardElement>
+            </div>
+            <div class="col" v-if="totalBattData.power || totalBattData.current">
+                <CardElement centerContent flexChildern textVariant="text-bg-success" :text="$t('invertertotalinfo.BatteryPower')">
+                    <div class="flex-fill" v-if="totalBattData.power">
+                        <h2>
+                            {{ $n(totalBattData.power.v, 'decimal', {
+                                minimumFractionDigits: totalBattData.power.d,
+                                maximumFractionDigits: totalBattData.power.d
+                            }) }}
+                            <small class="text-muted">{{ totalBattData.power.u }}</small>
+                        </h2>
+                    </div>
 
-                    <template v-if="totalBattData.voltage">
-                        {{ $n(totalBattData.voltage.v, 'decimal', {
-                            minimumFractionDigits: totalBattData.voltage.d,
-                            maximumFractionDigits: totalBattData.voltage.d
-                        }) }}
-                        <small class="text-muted">{{ totalBattData.voltage.u }}</small>
-                    </template>
-
-                    <template v-if="totalBattData.power">
-                        /
-                    </template>
-
-                    <template v-if="totalBattData.power">
-                        {{ $n(totalBattData.power.v, 'decimal', {
-                            minimumFractionDigits: totalBattData.power.d,
-                            maximumFractionDigits: totalBattData.power.d
-                        }) }}
-                        <small class="text-muted">{{ totalBattData.power.u }}</small>
-                    </template>
-                </h2>
-            </CardElement>
-        </div>
+                    <div class="flex-fill" v-if="totalBattData.current">
+                        <h2>
+                            {{ $n(totalBattData.current.v, 'decimal', {
+                                minimumFractionDigits: totalBattData.current.d,
+                                maximumFractionDigits: totalBattData.current.d
+                            }) }}
+                            <small class="text-muted">{{ totalBattData.current.u }}</small>
+                        </h2>
+                    </div>
+                </CardElement>
+            </div>
+        </template>
         <div class="col" v-if="powerMeterData.enabled">
             <CardElement centerContent textVariant="text-bg-success" :text="$t('invertertotalinfo.HomePower')">
                 <h2>

--- a/webapp/src/components/InverterTotalInfo.vue
+++ b/webapp/src/components/InverterTotalInfo.vue
@@ -68,7 +68,7 @@
         </div>
         <template v-if="totalBattData.enabled">
             <div class="col">
-                <CardElement centerContent flexChildern textVariant="text-bg-success" :text="$t('invertertotalinfo.BatteryCharge')">
+                <CardElement centerContent flexChildren textVariant="text-bg-success" :text="$t('invertertotalinfo.BatteryCharge')">
                     <div class="flex-fill" v-if="totalBattData.soc">
                         <h2>
                             {{ $n(totalBattData.soc.v, 'decimal', {
@@ -91,7 +91,7 @@
                 </CardElement>
             </div>
             <div class="col" v-if="totalBattData.power || totalBattData.current">
-                <CardElement centerContent flexChildern textVariant="text-bg-success" :text="$t('invertertotalinfo.BatteryPower')">
+                <CardElement centerContent flexChildren textVariant="text-bg-success" :text="$t('invertertotalinfo.BatteryPower')">
                     <div class="flex-fill" v-if="totalBattData.power">
                         <h2>
                             {{ $n(totalBattData.power.v, 'decimal', {

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -395,7 +395,8 @@
         "MpptTotalYieldTotal": "MPPT Gesamtertrag Insgesamt",
         "MpptTotalYieldDay": "MPPT Gesamtertrag Heute",
         "MpptTotalPower": "MPPT Gesamtleistung",
-        "Battery": "Batterie",
+        "BatteryCharge": "Batterie Ladezustand",
+        "BatteryPower": "Batterie Leistung",
         "HomePower": "Leistung / Netz",
         "HuaweiPower": "Huawei AC Leistung"
     },

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -395,7 +395,7 @@
         "MpptTotalYieldTotal": "MPPT Gesamtertrag Insgesamt",
         "MpptTotalYieldDay": "MPPT Gesamtertrag Heute",
         "MpptTotalPower": "MPPT Gesamtleistung",
-        "BatterySoc": "Ladezustand",
+        "Battery": "Batterie",
         "HomePower": "Leistung / Netz",
         "HuaweiPower": "Huawei AC Leistung"
     },

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -397,7 +397,8 @@
         "MpptTotalYieldTotal": "MPPT Total Yield Total",
         "MpptTotalYieldDay": "MPPT Total Yield Day",
         "MpptTotalPower": "MPPT Total Power",
-        "Battery": "Battery",
+        "BatteryCharge": "Battery Charge",
+        "BatteryPower": "Battery Power",
         "HomePower": "Grid Power",
         "HuaweiPower": "Huawei AC Power"
     },

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -397,7 +397,7 @@
         "MpptTotalYieldTotal": "MPPT Total Yield Total",
         "MpptTotalYieldDay": "MPPT Total Yield Day",
         "MpptTotalPower": "MPPT Total Power",
-        "BatterySoc": "State of charge",
+        "Battery": "Battery",
         "HomePower": "Grid Power",
         "HuaweiPower": "Huawei AC Power"
     },

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -430,7 +430,7 @@
         "MpptTotalYieldTotal": "MPPT rendement total",
         "MpptTotalYieldDay": "MPPT rendement du jour",
         "MpptTotalPower": "MPPT puissance de l'installation",
-        "BatterySoc": "State of charge",
+        "Battery": "Battery",
         "HomePower": "Grid Power",
         "HuaweiPower": "Huawei AC Power"
     },

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -430,7 +430,8 @@
         "MpptTotalYieldTotal": "MPPT rendement total",
         "MpptTotalYieldDay": "MPPT rendement du jour",
         "MpptTotalPower": "MPPT puissance de l'installation",
-        "Battery": "Battery",
+        "BatteryCharge": "Battery Charge",
+        "BatteryPower": "Battery Power",
         "HomePower": "Grid Power",
         "HuaweiPower": "Huawei AC Power"
     },

--- a/webapp/src/types/LiveDataStatus.ts
+++ b/webapp/src/types/LiveDataStatus.ts
@@ -61,7 +61,9 @@ export interface Huawei {
 
 export interface Battery {
   enabled: boolean;
-  soc: ValueObject;
+  soc?: ValueObject;
+  voltage?: ValueObject;
+  power?: ValueObject;
 }
 
 export interface PowerMeter {

--- a/webapp/src/types/LiveDataStatus.ts
+++ b/webapp/src/types/LiveDataStatus.ts
@@ -64,6 +64,7 @@ export interface Battery {
   soc?: ValueObject;
   voltage?: ValueObject;
   power?: ValueObject;
+  current?: ValueObject;
 }
 
 export interface PowerMeter {


### PR DESCRIPTION
Resolves https://github.com/helgeerbe/OpenDTU-OnBattery/issues/1129

- rename card title from `State of charge` to `Battery Charge`
- add `Battery Power` card
- show SoC, voltage, power and current if available
- move `_current` from individual implementations to `BatteryStats`
- add `_currentPrecision`
- use `_socPrecision` and `_currentPrecision` everywhere 

