### PR TITLE
improvement: add base class for hass discovery

### DIFF
--- a/include/BatteryStats.h
+++ b/include/BatteryStats.h
@@ -13,6 +13,7 @@
 class BatteryStats {
     public:
         String const& getManufacturer() const { return _manufacturer; }
+        String const& getFwVersion() const { return _fwversion; }
 
         // the last time *any* data was updated
         uint32_t getAgeSeconds() const { return (millis() - _lastUpdate) / 1000; }

--- a/include/MqttHandleBatteryHass.h
+++ b/include/MqttHandleBatteryHass.h
@@ -2,19 +2,22 @@
 #pragma once
 
 #include <ArduinoJson.h>
-#include <TaskSchedulerDeclarations.h>
+#include "MqttHassPublisher.h"
 
-class MqttHandleBatteryHassClass {
+class MqttHandleBatteryHassClass : public MqttHassPublisher {
 public:
     void init(Scheduler& scheduler);
     void forceUpdate() { _doPublish = true; }
 
 private:
     void loop();
-    void publish(const String& subtopic, const String& payload);
     void publishBinarySensor(const char* caption, const char* icon, const char* subTopic, const char* payload_on, const char* payload_off);
     void publishSensor(const char* caption, const char* icon, const char* subTopic, const char* deviceClass = NULL, const char* stateClass = NULL, const char* unitOfMeasurement = NULL);
-    void createDeviceInfo(JsonObject& object);
+
+    void publishBinarySensor2(const char* caption, const char* icon, const char* sensorId, const char* subTopic);
+    JsonObject createDeviceInfo();
+
+    String configTopicPrefix();
 
     Task _loopTask;
 

--- a/include/MqttHassPublisher.h
+++ b/include/MqttHassPublisher.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2024 Thomas Basler and others
+ */
+#pragma once
+
+#include <ArduinoJson.h>
+
+class MqttHassPublisher {
+public:
+    static void publish(const String& subtopic, const JsonDocument& payload);
+
+protected:
+    static JsonObject createDeviceInfo(const String& name, const String& identifiers, const String& model, const String& sw_version, const bool& via_dtu);
+    static String getDtuUniqueId();
+
+    void publishBinarySensor(const String& unique_dentifier, const String& name, const String& icon, const String& sensorId, const String& statSubTopic);
+
+    virtual String configTopicPrefix();
+    virtual JsonObject createDeviceInfo();
+
+private:
+    static String getDtuUrl();
+};

--- a/src/MqttHassPublisher.cpp
+++ b/src/MqttHassPublisher.cpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2024 Thomas Basler and others
+ */
+#include "MqttHassPublisher.h"
+#include "MqttSettings.h"
+#include "NetworkSettings.h"
+#include "Utils.h"
+#include "Configuration.h"
+
+void MqttHassPublisher::publish(const String& subtopic, const JsonDocument& payload)
+{
+    String buffer;
+    serializeJson(payload, buffer);
+
+    String topic = Configuration.get().Mqtt.Hass.Topic;
+    topic += subtopic;
+    MqttSettings.publishGeneric(topic, buffer, Configuration.get().Mqtt.Hass.Retain);
+}
+
+
+JsonObject MqttHassPublisher::createDeviceInfo(
+    const String& name, const String& identifiers,
+    const String& model, const String& sw_version,
+    const bool& via_dtu)
+{
+    JsonObject object;
+
+    object["name"] = name;
+    object["ids"] = identifiers;
+    object["cu"] = getDtuUrl(),
+    object["mf"] = "OpenDTU";
+    object["mdl"] = model;
+    object["sw"] = sw_version;
+
+    if (via_dtu) {
+        object["via_device"] = getDtuUniqueId();
+    }
+
+    return object;
+}
+
+void MqttHassPublisher::publishBinarySensor(
+    const String& unique_dentifier,
+    const String& name, const String& icon,
+    const String& sensorId, const String& statSubTopic)
+{
+    JsonDocument root;
+
+    root["name"] = name;
+    root["uniq_id"] = unique_dentifier;
+    root["stat_t"] = MqttSettings.getPrefix() + "/" + statSubTopic;
+    root["pl_on"] = "1";
+    root["pl_off"] = "0";
+
+    if (icon != nullptr) {
+        root["icon"] = icon;
+    }
+
+    root["dev"] = createDeviceInfo();
+
+    if (!Utils::checkJsonAlloc(root, __FUNCTION__, __LINE__)) {
+        return;
+    }
+
+    publish(
+        "binary_sensor/" + configTopicPrefix() + "/" + sensorId + "/config",
+        root
+    );
+}
+
+String MqttHassPublisher::getDtuUniqueId()
+{
+    return NetworkSettings.getHostname() + "_" + Utils::getChipId();
+}
+
+String MqttHassPublisher::getDtuUrl()
+{
+    return String("http://") + NetworkSettings.localIP().toString();
+}


### PR DESCRIPTION
I started to refactor how we build hass discovery as an outcome of this comment: https://github.com/helgeerbe/OpenDTU-OnBattery/pull/1136#issuecomment-2253279029

My idea is to create `MqttHassPublisher` as a library with static methods that can be used to publish sensors, buttons, fields and helpers like `createDeviceInfo`. 