### PR TITLE
Added unit for MQTT battery voltage

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -126,6 +126,8 @@ struct POWERMETER_HTTP_SML_CONFIG_T {
 };
 using PowerMeterHttpSmlConfig = struct POWERMETER_HTTP_SML_CONFIG_T;
 
+enum BatteryVoltageUnit { Volts = 0, DeciVolts = 1, CentiVolts = 2, MilliVolts = 3 };
+
 struct CONFIG_T {
     struct {
         uint32_t Version;
@@ -285,6 +287,7 @@ struct CONFIG_T {
         char MqttSocJsonPath[BATTERY_JSON_MAX_PATH_STRLEN + 1];
         char MqttVoltageTopic[MQTT_MAX_TOPIC_STRLEN + 1];
         char MqttVoltageJsonPath[BATTERY_JSON_MAX_PATH_STRLEN + 1];
+        BatteryVoltageUnit MqttVoltageUnit;
     } Battery;
 
     struct {

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -260,6 +260,7 @@ bool ConfigurationClass::write()
     battery["mqtt_json_path"] = config.Battery.MqttSocJsonPath;
     battery["mqtt_voltage_topic"] = config.Battery.MqttVoltageTopic;
     battery["mqtt_voltage_json_path"] = config.Battery.MqttVoltageJsonPath;
+    battery["mqtt_voltage_unit"] = config.Battery.MqttVoltageUnit;
 
     JsonObject huawei = doc["huawei"].to<JsonObject>();
     huawei["enabled"] = config.Huawei.Enabled;
@@ -609,6 +610,7 @@ bool ConfigurationClass::read()
     strlcpy(config.Battery.MqttSocJsonPath, battery["mqtt_json_path"] | "", sizeof(config.Battery.MqttSocJsonPath));
     strlcpy(config.Battery.MqttVoltageTopic, battery["mqtt_voltage_topic"] | "", sizeof(config.Battery.MqttVoltageTopic));
     strlcpy(config.Battery.MqttVoltageJsonPath, battery["mqtt_voltage_json_path"] | "", sizeof(config.Battery.MqttVoltageJsonPath));
+    config.Battery.MqttVoltageUnit = battery["mqtt_voltage_unit"] | BatteryVoltageUnit::Volts;
 
     JsonObject huawei = doc["huawei"];
     config.Huawei.Enabled = huawei["enabled"] | HUAWEI_ENABLED;

--- a/src/MqttBattery.cpp
+++ b/src/MqttBattery.cpp
@@ -90,7 +90,24 @@ void MqttBattery::onMqttMessageVoltage(espMqttClientTypes::MessageProperties con
             std::string(reinterpret_cast<const char*>(payload), len), topic,
             jsonPath);
 
+
     if (!voltage.has_value()) { return; }
+
+    auto const& config = Configuration.get();
+    using Unit_t = BatteryVoltageUnit;
+    switch (config.Battery.MqttVoltageUnit) {
+        case Unit_t::DeciVolts:
+            *voltage /= 10;
+            break;
+        case Unit_t::CentiVolts:
+            *voltage /= 100;
+            break;
+        case Unit_t::MilliVolts:
+            *voltage /= 1000;
+            break;
+        default:
+            break;
+    }
 
     // since this project is revolving around Hoymiles microinverters, which can
     // only handle up to 65V of input voltage at best, it is safe to assume that

--- a/src/WebApi_battery.cpp
+++ b/src/WebApi_battery.cpp
@@ -30,7 +30,7 @@ void WebApiBatteryClass::onStatus(AsyncWebServerRequest* request)
     if (!WebApi.checkCredentialsReadonly(request)) {
         return;
     }
-    
+
     AsyncJsonResponse* response = new AsyncJsonResponse();
     auto& root = response->getRoot();
     const CONFIG_T& config = Configuration.get();
@@ -44,6 +44,7 @@ void WebApiBatteryClass::onStatus(AsyncWebServerRequest* request)
     root["mqtt_soc_json_path"] = config.Battery.MqttSocJsonPath;
     root["mqtt_voltage_topic"] = config.Battery.MqttVoltageTopic;
     root["mqtt_voltage_json_path"] = config.Battery.MqttVoltageJsonPath;
+    root["mqtt_voltage_unit"] = config.Battery.MqttVoltageUnit;
 
     response->setLength();
     request->send(response);
@@ -85,6 +86,7 @@ void WebApiBatteryClass::onAdminPost(AsyncWebServerRequest* request)
     strlcpy(config.Battery.MqttSocJsonPath, root["mqtt_soc_json_path"].as<String>().c_str(), sizeof(config.Battery.MqttSocJsonPath));
     strlcpy(config.Battery.MqttVoltageTopic, root["mqtt_voltage_topic"].as<String>().c_str(), sizeof(config.Battery.MqttVoltageTopic));
     strlcpy(config.Battery.MqttVoltageJsonPath, root["mqtt_voltage_json_path"].as<String>().c_str(), sizeof(config.Battery.MqttVoltageJsonPath));
+    config.Battery.MqttVoltageUnit = static_cast<BatteryVoltageUnit>(root["mqtt_voltage_unit"].as<uint8_t>());
 
     WebApi.writeConfig(retMsg);
 

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -675,6 +675,7 @@
         "MqttVoltageConfiguration": "Einstellungen Spannung",
         "MqttJsonPath": "Optional: JSON-Pfad",
         "MqttJsonPathDescription": "Anwendungsspezifischer JSON-Pfad um den Wert in den JSON Nutzdatzen zu finden, z.B. 'electricLevel'. Leer lassen, falls die Nutzdaten des Topics einen numerischen Wert enthält.",
+        "MqttVoltageUnit": "Einheit",
         "MqttSocTopic": "Topic für SoC",
         "MqttVoltageTopic": "Topic für Spannung",
         "JkBmsConfiguration": "JK BMS Einstellungen",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -678,6 +678,7 @@
         "MqttVoltageConfiguration": "Voltage Settings",
         "MqttJsonPath": "Optional: JSON Path",
         "MqttJsonPathDescription": "Application specific JSON path to find the value in the JSON payload, e.g., 'electricLevel'. Leave empty if the topic's payload contains a plain numeric value.",
+        "MqttVoltageUnit": "Unit",
         "MqttSocTopic": "SoC Value Topic",
         "MqttVoltageTopic": "Voltage Value Topic",
         "JkBmsConfiguration": "JK BMS Settings",

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -601,6 +601,7 @@
         "MqttVoltageConfiguration": "Voltage Settings",
         "MqttJsonPath": "Optional: JSON Path",
         "MqttJsonPathDescription": "Application specific JSON path to find the value in the JSON payload, e.g., 'electricLevel'. Leave empty if the topic's payload contains a plain numeric value.",
+        "MqttVoltageUnit": "Unit",
         "MqttSocTopic": "SoC Value Topic",
         "MqttVoltageTopic": "Voltage Value Topic",
         "JkBmsConfiguration": "JK BMS Settings",

--- a/webapp/src/types/BatteryConfig.ts
+++ b/webapp/src/types/BatteryConfig.ts
@@ -8,4 +8,5 @@ export interface BatteryConfig {
     mqtt_soc_json_path: string;
     mqtt_voltage_topic: string;
     mqtt_voltage_json_path: string;
+    mqtt_voltage_unit: number;
 }

--- a/webapp/src/views/BatteryAdminView.vue
+++ b/webapp/src/views/BatteryAdminView.vue
@@ -78,6 +78,18 @@
                         maxlength="128"
                         :tooltip="$t('batteryadmin.MqttJsonPathDescription')" />
 
+                    <div class="row mb-3">
+                        <label for="mqtt_voltage_unit" class="col-sm-4 col-form-label">
+                            {{ $t('batteryadmin.MqttVoltageUnit') }}
+                        </label>
+                        <div class="col-sm-8">
+                            <select id="mqtt_voltage_unit" class="form-select" v-model="batteryConfigList.mqtt_voltage_unit">
+                                <option v-for="u in voltageUnitTypeList" :key="u.key" :value="u.key">
+                                    {{ u.value }}
+                                </option>
+                            </select>
+                        </div>
+                    </div>
                 </CardElement>
             </template>
 
@@ -121,6 +133,12 @@ export default defineComponent({
             jkBmsInterfaceTypeList: [
                 { key: 0, value: 'Uart' },
                 { key: 1, value: 'Transceiver' },
+            ],
+            voltageUnitTypeList: [
+                { key: 3, value: "mV" },
+                { key: 2, value: "cV" },
+                { key: 1, value: "dV" },
+                { key: 0, value: "V" },
             ],
         };
     },

--- a/webapp/src/views/BatteryAdminView.vue
+++ b/webapp/src/views/BatteryAdminView.vue
@@ -79,10 +79,10 @@
                         :tooltip="$t('batteryadmin.MqttJsonPathDescription')" />
 
                     <div class="row mb-3">
-                        <label for="mqtt_voltage_unit" class="col-sm-4 col-form-label">
+                        <label for="mqtt_voltage_unit" class="col-sm-2 col-form-label">
                             {{ $t('batteryadmin.MqttVoltageUnit') }}
                         </label>
-                        <div class="col-sm-8">
+                        <div class="col-sm-10">
                             <select id="mqtt_voltage_unit" class="form-select" v-model="batteryConfigList.mqtt_voltage_unit">
                                 <option v-for="u in voltageUnitTypeList" :key="u.key" :value="u.key">
                                     {{ u.value }}


### PR DESCRIPTION
Implemented the - at least for my setup - missing unit for battery voltage received via MQTT. It compiles locally ~~, but could not test WebUI integration.~~ and was successfully tested on my Fusion board 