### PR TITLE
feature: SPIPortManager to allow use of CMT radio and Huawei charger at the same time

### DIFF
--- a/include/SPIPortManager.h
+++ b/include/SPIPortManager.h
@@ -9,15 +9,20 @@
 /**
  * SPI# to SPI ID and SPI_HOST mapping
  *
+ * ESP32
+ * | SPI # | SPI ID | SPI_HOST |
+ * | 2     | 2      | 1        |
+ * | 3     | 3      | 2        |
+ *
  * ESP32-S3
  * | SPI # | SPI ID | SPI_HOST |
  * | 2     | 0      | 1        |
  * | 3     | 1      | 2        |
  *
- * ESP32
+ * ESP32-C3
  * | SPI # | SPI ID | SPI_HOST |
- * | 2     | 2      | 1        |
- * | 3     | 3      | 2        |
+ * | 2     | 0      | 1        |
+ *
  */
 
 class SPIPortManagerClass {

--- a/include/SPIPortManager.h
+++ b/include/SPIPortManager.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <SPI.h>
+#include <array>
+#include <optional>
+#include <string>
+
+/**
+ * SPI# to SPI ID and SPI_HOST mapping
+ *
+ * ESP32-S3
+ * | SPI # | SPI ID | SPI_HOST |
+ * | 0     | 0      | 0        |
+ * | 1     | 1      | 1        |
+ * | 2     | 3      | 2        |
+ *
+ * ESP32
+ * | SPI # | SPI ID | SPI_HOST |
+ * | 0     | 1      | 0        |
+ * | 1     | 2      | 1        |
+ * | 2     | 3      | 2        |
+ */
+
+class SPIPortManagerClass {
+public:
+    void init();
+
+    std::optional<uint8_t> allocatePort(std::string const& owner);
+    void freePort(std::string const& owner);
+
+private:
+    // the amount of SPIs available on supported ESP32 chips
+    // TODO(AndreasBoehm): this does not work as expected on non S3 ESPs
+    static size_t constexpr _num_controllers = SOC_SPI_PERIPH_NUM;
+
+    // TODO(AndreasBoehm): using a simple array like this does not work well when we want to support ESP32 and ESP32-S3
+    std::array<std::string, _num_controllers> _ports = { "" };
+};
+
+extern SPIPortManagerClass SPIPortManager;

--- a/include/SPIPortManager.h
+++ b/include/SPIPortManager.h
@@ -32,7 +32,7 @@ public:
     std::optional<uint8_t> allocatePort(std::string const& owner);
     void freePort(std::string const& owner);
 
-    spi_host_device_t SPIhostNum(uint8_t spi_num) { return (spi_host_device_t)(spi_num + _offset_spi_num); }
+    spi_host_device_t SPIhostNum(uint8_t spi_num) { return (spi_host_device_t)(spi_num + _offset_spi_host); }
 
 private:
     // the amount of SPIs available on supported ESP32 chips

--- a/include/SPIPortManager.h
+++ b/include/SPIPortManager.h
@@ -11,15 +11,13 @@
  *
  * ESP32-S3
  * | SPI # | SPI ID | SPI_HOST |
- * | 0     | 0      | 0        |
- * | 1     | 1      | 1        |
- * | 2     | 3      | 2        |
+ * | 2     | 0      | 1        |
+ * | 3     | 1      | 2        |
  *
  * ESP32
  * | SPI # | SPI ID | SPI_HOST |
- * | 0     | 1      | 0        |
- * | 1     | 2      | 1        |
- * | 2     | 3      | 2        |
+ * | 2     | 2      | 1        |
+ * | 3     | 3      | 2        |
  */
 
 class SPIPortManagerClass {
@@ -33,11 +31,7 @@ public:
 
 private:
     // the amount of SPIs available on supported ESP32 chips
-    #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
-    static size_t constexpr _num_controllers = 2;
-    #else
-    static size_t constexpr _num_controllers = 1;
-    #endif
+    static size_t constexpr _num_controllers = SOC_SPI_PERIPH_NUM - 1; // minus one because SPI1 can't be used
 
     #if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
     static int8_t constexpr _offset_spi_num = 0;  // FSPI=0, HSPI=1

--- a/include/SPIPortManager.h
+++ b/include/SPIPortManager.h
@@ -31,8 +31,7 @@ public:
 
     std::optional<uint8_t> allocatePort(std::string const& owner);
     void freePort(std::string const& owner);
-
-    spi_host_device_t SPIhostNum(uint8_t spi_num) { return (spi_host_device_t)(spi_num + _offset_spi_host); }
+    spi_host_device_t SPIhostNum(uint8_t spi_num);
 
 private:
     // the amount of SPIs available on supported ESP32 chips

--- a/include/SPIPortManager.h
+++ b/include/SPIPortManager.h
@@ -36,13 +36,17 @@ public:
 
 private:
     // the amount of SPIs available on supported ESP32 chips
-    static size_t constexpr _num_controllers = SOC_SPI_PERIPH_NUM - 1; // minus one because SPI1 can't be used
+    #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S3
+    static size_t constexpr _num_controllers = 4;
+    #else
+    static size_t constexpr _num_controllers = 3;
+    #endif
 
     #if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
-    static int8_t constexpr _offset_spi_num = 0;  // FSPI=0, HSPI=1
+    static int8_t constexpr _offset_spi_num = -2;  // FSPI=0, HSPI=1
     static int8_t constexpr _offset_spi_host = 1; // SPI1_HOST=0 but not usable, SPI2_HOST=1 and SPI3_HOST=2, first usable is SPI2_HOST
     #else
-    static int8_t constexpr _offset_spi_num = 2; // HSPI=2, VSPI=3
+    static int8_t constexpr _offset_spi_num = 0; // HSPI=2, VSPI=3
     static int8_t constexpr _offset_spi_host = -1; // SPI1_HOST=0 but not usable, SPI2_HOST=1 and SPI3_HOST=2, first usable is SPI2_HOST
     #endif
 

--- a/lib/CMT2300a/cmt2300a_hal.c
+++ b/lib/CMT2300a/cmt2300a_hal.c
@@ -26,9 +26,9 @@
  * @name    CMT2300A_InitSpi
  * @desc    Initializes the CMT2300A SPI interface.
  * *********************************************************/
-void CMT2300A_InitSpi(const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed)
+void CMT2300A_InitSpi(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed)
 {
-    cmt_spi3_init(pin_sdio, pin_clk, pin_cs, pin_fcs, spi_speed);
+    cmt_spi3_init(spi_host, pin_sdio, pin_clk, pin_cs, pin_fcs, spi_speed);
 }
 
 /*! ********************************************************

--- a/lib/CMT2300a/cmt2300a_hal.c
+++ b/lib/CMT2300a/cmt2300a_hal.c
@@ -26,7 +26,7 @@
  * @name    CMT2300A_InitSpi
  * @desc    Initializes the CMT2300A SPI interface.
  * *********************************************************/
-void CMT2300A_InitSpi(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed)
+void CMT2300A_InitSpi(const spi_host_device_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed)
 {
     cmt_spi3_init(spi_host, pin_sdio, pin_clk, pin_cs, pin_fcs, spi_speed);
 }

--- a/lib/CMT2300a/cmt2300a_hal.h
+++ b/lib/CMT2300a/cmt2300a_hal.h
@@ -23,6 +23,7 @@
 
 #include <stdint.h>
 #include <Arduino.h>
+#include <driver/spi_master.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,7 +37,7 @@ extern "C" {
 #define CMT2300A_GetTickCount() millis()
 /* ************************************************************************ */
 
-void CMT2300A_InitSpi(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed);
+void CMT2300A_InitSpi(const spi_host_device_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed);
 
 uint8_t CMT2300A_ReadReg(const uint8_t addr);
 void CMT2300A_WriteReg(const uint8_t addr, const uint8_t dat);

--- a/lib/CMT2300a/cmt2300a_hal.h
+++ b/lib/CMT2300a/cmt2300a_hal.h
@@ -36,7 +36,7 @@ extern "C" {
 #define CMT2300A_GetTickCount() millis()
 /* ************************************************************************ */
 
-void CMT2300A_InitSpi(const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed);
+void CMT2300A_InitSpi(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed);
 
 uint8_t CMT2300A_ReadReg(const uint8_t addr);
 void CMT2300A_WriteReg(const uint8_t addr, const uint8_t dat);

--- a/lib/CMT2300a/cmt2300wrapper.cpp
+++ b/lib/CMT2300a/cmt2300wrapper.cpp
@@ -7,7 +7,7 @@
 #include "cmt2300a_params_860.h"
 #include "cmt2300a_params_900.h"
 
-CMT2300A::CMT2300A(const int8_t spi_host, const uint8_t pin_sdio, const uint8_t pin_clk, const uint8_t pin_cs, const uint8_t pin_fcs, const uint32_t spi_speed)
+CMT2300A::CMT2300A(const spi_host_device_t spi_host, const uint8_t pin_sdio, const uint8_t pin_clk, const uint8_t pin_cs, const uint8_t pin_fcs, const uint32_t spi_speed)
 {
     _spi_host = spi_host;
     _pin_sdio = pin_sdio;

--- a/lib/CMT2300a/cmt2300wrapper.cpp
+++ b/lib/CMT2300a/cmt2300wrapper.cpp
@@ -7,8 +7,9 @@
 #include "cmt2300a_params_860.h"
 #include "cmt2300a_params_900.h"
 
-CMT2300A::CMT2300A(const uint8_t pin_sdio, const uint8_t pin_clk, const uint8_t pin_cs, const uint8_t pin_fcs, const uint32_t spi_speed)
+CMT2300A::CMT2300A(const int8_t spi_host, const uint8_t pin_sdio, const uint8_t pin_clk, const uint8_t pin_cs, const uint8_t pin_fcs, const uint32_t spi_speed)
 {
+    _spi_host = spi_host;
     _pin_sdio = pin_sdio;
     _pin_clk = pin_clk;
     _pin_cs = pin_cs;
@@ -266,7 +267,7 @@ void CMT2300A::flush_rx(void)
 
 bool CMT2300A::_init_pins()
 {
-    CMT2300A_InitSpi(_pin_sdio, _pin_clk, _pin_cs, _pin_fcs, _spi_speed);
+    CMT2300A_InitSpi(_spi_host, _pin_sdio, _pin_clk, _pin_cs, _pin_fcs, _spi_speed);
 
     return true; // assuming pins are connected properly
 }

--- a/lib/CMT2300a/cmt2300wrapper.h
+++ b/lib/CMT2300a/cmt2300wrapper.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <driver/spi_master.h>
 
 #define CMT2300A_ONE_STEP_SIZE 2500 // frequency channel step size for fast frequency hopping operation: One step size is 2.5 kHz.
 #define FH_OFFSET 100 // value * CMT2300A_ONE_STEP_SIZE = channel frequency offset
@@ -18,7 +19,7 @@ enum FrequencyBand_t {
 
 class CMT2300A {
 public:
-    CMT2300A(const int8_t spi_host, const uint8_t pin_sdio, const uint8_t pin_clk, const uint8_t pin_cs, const uint8_t pin_fcs, const uint32_t _spi_speed = CMT_SPI_SPEED);
+    CMT2300A(const spi_host_device_t spi_host, const uint8_t pin_sdio, const uint8_t pin_clk, const uint8_t pin_cs, const uint8_t pin_fcs, const uint32_t _spi_speed = CMT_SPI_SPEED);
 
     bool begin(void);
 
@@ -128,7 +129,7 @@ private:
      */
     bool _init_radio();
 
-    int8_t _spi_host;
+    spi_host_device_t _spi_host;
     int8_t _pin_sdio;
     int8_t _pin_clk;
     int8_t _pin_cs;

--- a/lib/CMT2300a/cmt2300wrapper.h
+++ b/lib/CMT2300a/cmt2300wrapper.h
@@ -18,7 +18,7 @@ enum FrequencyBand_t {
 
 class CMT2300A {
 public:
-    CMT2300A(const uint8_t pin_sdio, const uint8_t pin_clk, const uint8_t pin_cs, const uint8_t pin_fcs, const uint32_t _spi_speed = CMT_SPI_SPEED);
+    CMT2300A(const int8_t spi_host, const uint8_t pin_sdio, const uint8_t pin_clk, const uint8_t pin_cs, const uint8_t pin_fcs, const uint32_t _spi_speed = CMT_SPI_SPEED);
 
     bool begin(void);
 
@@ -128,6 +128,7 @@ private:
      */
     bool _init_radio();
 
+    int8_t _spi_host;
     int8_t _pin_sdio;
     int8_t _pin_clk;
     int8_t _pin_cs;

--- a/lib/CMT2300a/cmt_spi3.c
+++ b/lib/CMT2300a/cmt_spi3.c
@@ -9,14 +9,9 @@ SemaphoreHandle_t paramLock = NULL;
     } while (xSemaphoreTake(paramLock, portMAX_DELAY) != pdPASS)
 #define SPI_PARAM_UNLOCK() xSemaphoreGive(paramLock)
 
-// for ESP32 this is the so-called HSPI
-// for ESP32-S2/S3/C3 this nomenclature does not really exist anymore,
-// it is simply the first externally usable hardware SPI master controller
-#define SPI_CMT SPI2_HOST
-
 spi_device_handle_t spi_reg, spi_fifo;
 
-void cmt_spi3_init(const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed)
+void cmt_spi3_init(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed)
 {
     paramLock = xSemaphoreCreateMutex();
 
@@ -43,8 +38,8 @@ void cmt_spi3_init(const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin
         .post_cb = NULL,
     };
 
-    ESP_ERROR_CHECK(spi_bus_initialize(SPI_CMT, &buscfg, SPI_DMA_DISABLED));
-    ESP_ERROR_CHECK(spi_bus_add_device(SPI_CMT, &devcfg, &spi_reg));
+    ESP_ERROR_CHECK(spi_bus_initialize(spi_host, &buscfg, SPI_DMA_DISABLED));
+    ESP_ERROR_CHECK(spi_bus_add_device(spi_host, &devcfg, &spi_reg));
 
     // FiFo
     spi_device_interface_config_t devcfg2 = {
@@ -61,9 +56,9 @@ void cmt_spi3_init(const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin
         .pre_cb = NULL,
         .post_cb = NULL,
     };
-    ESP_ERROR_CHECK(spi_bus_add_device(SPI_CMT, &devcfg2, &spi_fifo));
+    ESP_ERROR_CHECK(spi_bus_add_device(spi_host, &devcfg2, &spi_fifo));
 
-    esp_rom_gpio_connect_out_signal(pin_sdio, spi_periph_signal[SPI_CMT].spid_out, true, false);
+    esp_rom_gpio_connect_out_signal(pin_sdio, spi_periph_signal[spi_host].spid_out, true, false);
     delay(100);
 }
 

--- a/lib/CMT2300a/cmt_spi3.c
+++ b/lib/CMT2300a/cmt_spi3.c
@@ -1,6 +1,5 @@
 #include "cmt_spi3.h"
 #include <Arduino.h>
-#include <driver/spi_master.h>
 #include <esp_rom_gpio.h> // for esp_rom_gpio_connect_out_signal
 
 SemaphoreHandle_t paramLock = NULL;
@@ -11,7 +10,7 @@ SemaphoreHandle_t paramLock = NULL;
 
 spi_device_handle_t spi_reg, spi_fifo;
 
-void cmt_spi3_init(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed)
+void cmt_spi3_init(const spi_host_device_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed)
 {
     paramLock = xSemaphoreCreateMutex();
 

--- a/lib/CMT2300a/cmt_spi3.h
+++ b/lib/CMT2300a/cmt_spi3.h
@@ -2,8 +2,9 @@
 #define __CMT_SPI3_H
 
 #include <stdint.h>
+#include <driver/spi_master.h>
 
-void cmt_spi3_init(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed);
+void cmt_spi3_init(const spi_host_device_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed);
 
 void cmt_spi3_write(const uint8_t addr, const uint8_t dat);
 uint8_t cmt_spi3_read(const uint8_t addr);

--- a/lib/CMT2300a/cmt_spi3.h
+++ b/lib/CMT2300a/cmt_spi3.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-void cmt_spi3_init(const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed);
+void cmt_spi3_init(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const uint32_t spi_speed);
 
 void cmt_spi3_write(const uint8_t addr, const uint8_t dat);
 uint8_t cmt_spi3_read(const uint8_t addr);

--- a/lib/Hoymiles/src/Hoymiles.cpp
+++ b/lib/Hoymiles/src/Hoymiles.cpp
@@ -31,9 +31,9 @@ void HoymilesClass::initNRF(SPIClass* initialisedSpiBus, const uint8_t pinCE, co
     _radioNrf->init(initialisedSpiBus, pinCE, pinIRQ);
 }
 
-void HoymilesClass::initCMT(const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3)
+void HoymilesClass::initCMT(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3)
 {
-    _radioCmt->init(pin_sdio, pin_clk, pin_cs, pin_fcs, pin_gpio2, pin_gpio3);
+    _radioCmt->init(spi_host, pin_sdio, pin_clk, pin_cs, pin_fcs, pin_gpio2, pin_gpio3);
 }
 
 void HoymilesClass::loop()

--- a/lib/Hoymiles/src/Hoymiles.cpp
+++ b/lib/Hoymiles/src/Hoymiles.cpp
@@ -31,7 +31,7 @@ void HoymilesClass::initNRF(SPIClass* initialisedSpiBus, const uint8_t pinCE, co
     _radioNrf->init(initialisedSpiBus, pinCE, pinIRQ);
 }
 
-void HoymilesClass::initCMT(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3)
+void HoymilesClass::initCMT(const spi_host_device_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3)
 {
     _radioCmt->init(spi_host, pin_sdio, pin_clk, pin_cs, pin_fcs, pin_gpio2, pin_gpio3);
 }

--- a/lib/Hoymiles/src/Hoymiles.h
+++ b/lib/Hoymiles/src/Hoymiles.h
@@ -17,7 +17,7 @@ class HoymilesClass {
 public:
     void init();
     void initNRF(SPIClass* initialisedSpiBus, const uint8_t pinCE, const uint8_t pinIRQ);
-    void initCMT(const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3);
+    void initCMT(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3);
     void loop();
 
     void setMessageOutput(Print* output);

--- a/lib/Hoymiles/src/Hoymiles.h
+++ b/lib/Hoymiles/src/Hoymiles.h
@@ -9,6 +9,7 @@
 #include <SPI.h>
 #include <memory>
 #include <vector>
+#include <driver/spi_master.h>
 
 #define HOY_SYSTEM_CONFIG_PARA_POLL_INTERVAL (2 * 60 * 1000) // 2 minutes
 #define HOY_SYSTEM_CONFIG_PARA_POLL_MIN_DURATION (4 * 60 * 1000) // at least 4 minutes between sending limit command and read request. Otherwise eventlog entry
@@ -17,7 +18,7 @@ class HoymilesClass {
 public:
     void init();
     void initNRF(SPIClass* initialisedSpiBus, const uint8_t pinCE, const uint8_t pinIRQ);
-    void initCMT(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3);
+    void initCMT(const spi_host_device_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3);
     void loop();
 
     void setMessageOutput(Print* output);

--- a/lib/Hoymiles/src/HoymilesRadio_CMT.cpp
+++ b/lib/Hoymiles/src/HoymilesRadio_CMT.cpp
@@ -83,11 +83,11 @@ bool HoymilesRadio_CMT::cmtSwitchDtuFreq(const uint32_t to_frequency)
     return true;
 }
 
-void HoymilesRadio_CMT::init(const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3)
+void HoymilesRadio_CMT::init(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3)
 {
     _dtuSerial.u64 = 0;
 
-    _radio.reset(new CMT2300A(pin_sdio, pin_clk, pin_cs, pin_fcs));
+    _radio.reset(new CMT2300A(spi_host, pin_sdio, pin_clk, pin_cs, pin_fcs));
 
     _radio->begin();
 

--- a/lib/Hoymiles/src/HoymilesRadio_CMT.cpp
+++ b/lib/Hoymiles/src/HoymilesRadio_CMT.cpp
@@ -83,7 +83,7 @@ bool HoymilesRadio_CMT::cmtSwitchDtuFreq(const uint32_t to_frequency)
     return true;
 }
 
-void HoymilesRadio_CMT::init(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3)
+void HoymilesRadio_CMT::init(const spi_host_device_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3)
 {
     _dtuSerial.u64 = 0;
 

--- a/lib/Hoymiles/src/HoymilesRadio_CMT.h
+++ b/lib/Hoymiles/src/HoymilesRadio_CMT.h
@@ -41,7 +41,7 @@ struct CountryFrequencyList_t {
 
 class HoymilesRadio_CMT : public HoymilesRadio {
 public:
-    void init(const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3);
+    void init(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3);
     void loop();
     void setPALevel(const int8_t paLevel);
     void setInverterTargetFrequency(const uint32_t frequency);

--- a/lib/Hoymiles/src/HoymilesRadio_CMT.h
+++ b/lib/Hoymiles/src/HoymilesRadio_CMT.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <queue>
 #include <vector>
+#include <driver/spi_master.h>
 
 // number of fragments hold in buffer
 #define FRAGMENT_BUFFER_SIZE 30
@@ -41,7 +42,7 @@ struct CountryFrequencyList_t {
 
 class HoymilesRadio_CMT : public HoymilesRadio {
 public:
-    void init(const int8_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3);
+    void init(const spi_host_device_t spi_host, const int8_t pin_sdio, const int8_t pin_clk, const int8_t pin_cs, const int8_t pin_fcs, const int8_t pin_gpio2, const int8_t pin_gpio3);
     void loop();
     void setPALevel(const int8_t paLevel);
     void setInverterTargetFrequency(const uint32_t frequency);

--- a/src/Huawei_can.cpp
+++ b/src/Huawei_can.cpp
@@ -9,6 +9,7 @@
 #include "PowerLimiter.h"
 #include "Configuration.h"
 #include "Battery.h"
+#include "SPIPortManager.h"
 #include <SPI.h>
 #include <mcp_can.h>
 
@@ -35,7 +36,11 @@ void HuaweiCanCommunicationTask(void* parameter) {
 
 bool HuaweiCanCommClass::init(uint8_t huawei_miso, uint8_t huawei_mosi, uint8_t huawei_clk,
         uint8_t huawei_irq, uint8_t huawei_cs, uint32_t frequency) {
-    SPI = new SPIClass(HSPI);
+
+    auto oSPInum = SPIPortManager.allocatePort("Huawei CAN");
+    if (!oSPInum) { return false; }
+
+    SPI = new SPIClass(*oSPInum);
     SPI->begin(huawei_clk, huawei_miso, huawei_mosi, huawei_cs);
     pinMode(huawei_cs, OUTPUT);
     digitalWrite(huawei_cs, HIGH);

--- a/src/Huawei_can.cpp
+++ b/src/Huawei_can.cpp
@@ -236,7 +236,7 @@ void HuaweiCanClass::updateSettings(uint8_t huawei_miso, uint8_t huawei_mosi, ui
       _mode = HUAWEI_MODE_AUTO_INT;
     }
 
-    xTaskCreate(HuaweiCanCommunicationTask,"HUAWEI_CAN_0",1000,NULL,0,&_HuaweiCanCommunicationTaskHdl);
+    xTaskCreate(HuaweiCanCommunicationTask,"HUAWEI_CAN_0",2000,NULL,0,&_HuaweiCanCommunicationTaskHdl);
 
     MessageOutput.println("[HuaweiCanClass::init] MCP2515 Initialized Successfully!");
     _initialized = true;

--- a/src/InverterSettings.cpp
+++ b/src/InverterSettings.cpp
@@ -24,7 +24,7 @@ void InverterSettingsClass::init(Scheduler& scheduler)
     const PinMapping_t& pin = PinMapping.get();
 
     // Initialize inverter communication
-    MessageOutput.print("Initialize Hoymiles interface... ");
+    MessageOutput.println("Initialize Hoymiles interface... ");
 
     Hoymiles.setMessageOutput(&MessageOutput);
     Hoymiles.init();
@@ -34,7 +34,7 @@ void InverterSettingsClass::init(Scheduler& scheduler)
             auto oSPInum = SPIPortManager.allocatePort("NRF24");
 
             if (oSPInum) {
-                SPIClass* spiClass = new SPIClass(*oSPInum); // 0 gut, 1 gut, 2 schlecht
+                SPIClass* spiClass = new SPIClass(*oSPInum);
                 spiClass->begin(pin.nrf24_clk, pin.nrf24_miso, pin.nrf24_mosi, pin.nrf24_cs);
                 Hoymiles.initNRF(spiClass, pin.nrf24_en, pin.nrf24_irq);
             }
@@ -44,9 +44,7 @@ void InverterSettingsClass::init(Scheduler& scheduler)
             auto oSPInum = SPIPortManager.allocatePort("CMT2300A");
 
             if (oSPInum) {
-                // TODO(AndreasBoehm): this only works on an ESP32-S3 like this, we need to find a different way to also make this work on an ESP32
-                // oSPInum + 1 to make it work
-                Hoymiles.initCMT(*oSPInum + 1, pin.cmt_sdio, pin.cmt_clk, pin.cmt_cs, pin.cmt_fcs, pin.cmt_gpio2, pin.cmt_gpio3);
+                Hoymiles.initCMT(SPIPortManager.SPIhostNum(*oSPInum), pin.cmt_sdio, pin.cmt_clk, pin.cmt_cs, pin.cmt_fcs, pin.cmt_gpio2, pin.cmt_gpio3);
                 MessageOutput.println("  Setting country mode... ");
                 Hoymiles.getRadioCmt()->setCountryMode(static_cast<CountryModeId_t>(config.Dtu.Cmt.CountryMode));
                 MessageOutput.println("  Setting CMT target frequency... ");

--- a/src/InverterSettings.cpp
+++ b/src/InverterSettings.cpp
@@ -52,8 +52,6 @@ void InverterSettingsClass::init(Scheduler& scheduler)
             }
         }
 
-        // TODO(AndreasBoehm): do something when we could not allocate the port for any of the valid configured pin mappings
-
         MessageOutput.println("  Setting radio PA level... ");
         Hoymiles.getRadioNrf()->setPALevel((rf24_pa_dbm_e)config.Dtu.Nrf.PaLevel);
         Hoymiles.getRadioCmt()->setPALevel(config.Dtu.Cmt.PaLevel);

--- a/src/SPIPortManager.cpp
+++ b/src/SPIPortManager.cpp
@@ -5,26 +5,23 @@
 SPIPortManagerClass SPIPortManager;
 static constexpr char  TAG[] = "[SPIPortManager]";
 
-void SPIPortManagerClass::init()
-{
-    MessageOutput.printf("%s SPI0 and SPI1 reserved by 'Flash and PSRAM'\r\n", TAG);
-    // _ports[0] = "Flash";
-    // _ports[1] = "PSRAM";
-}
+void SPIPortManagerClass::init() {}
 
 std::optional<uint8_t> SPIPortManagerClass::allocatePort(std::string const& owner)
 {
     for (size_t i = 0; i < _ports.size(); ++i) {
+        auto spiNum = i + _offset_spi_num;
+
         if (_ports[i] != "") {
-            MessageOutput.printf("%s SPI%d already in use by '%s'\r\n", TAG, i, _ports[i].c_str());
+            MessageOutput.printf("%s SPI%d already in use by '%s'\r\n", TAG, spiNum, _ports[i].c_str());
             continue;
         }
 
         _ports[i] = owner;
 
-        MessageOutput.printf("%s SPI%d now in use by '%s'\r\n", TAG, i, owner.c_str());
+        MessageOutput.printf("%s SPI%d now in use by '%s'\r\n", TAG, spiNum, owner.c_str());
 
-        return i;
+        return spiNum;
     }
 
     MessageOutput.printf("%s Cannot assign another SPI port to '%s'\r\n", TAG, owner.c_str());
@@ -36,7 +33,7 @@ void SPIPortManagerClass::freePort(std::string const& owner)
     for (size_t i = 0; i < _ports.size(); ++i) {
         if (_ports[i] != owner) { continue; }
 
-        MessageOutput.printf("%s Freeing SPI%d, owner was '%s'\r\n", TAG, i, owner.c_str());
+        MessageOutput.printf("%s Freeing SPI%d, owner was '%s'\r\n", TAG, i + _offset_spi_num, owner.c_str());
         _ports[i] = "";
     }
 }

--- a/src/SPIPortManager.cpp
+++ b/src/SPIPortManager.cpp
@@ -39,3 +39,8 @@ void SPIPortManagerClass::freePort(std::string const& owner)
         _ports[i] = "";
     }
 }
+
+spi_host_device_t SPIPortManagerClass::SPIhostNum(uint8_t spi_num)
+{
+    return (spi_host_device_t)(spi_num + _offset_spi_host);
+}

--- a/src/SPIPortManager.cpp
+++ b/src/SPIPortManager.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "SPIPortManager.h"
+#include "MessageOutput.h"
+
+SPIPortManagerClass SPIPortManager;
+static constexpr char  TAG[] = "[SPIPortManager]";
+
+void SPIPortManagerClass::init()
+{
+    MessageOutput.printf("%s SPI0 and SPI1 reserved by 'Flash and PSRAM'\r\n", TAG);
+    // _ports[0] = "Flash";
+    // _ports[1] = "PSRAM";
+}
+
+std::optional<uint8_t> SPIPortManagerClass::allocatePort(std::string const& owner)
+{
+    for (size_t i = 0; i < _ports.size(); ++i) {
+        if (_ports[i] != "") {
+            MessageOutput.printf("%s SPI%d already in use by '%s'\r\n", TAG, i, _ports[i].c_str());
+            continue;
+        }
+
+        _ports[i] = owner;
+
+        MessageOutput.printf("%s SPI%d now in use by '%s'\r\n", TAG, i, owner.c_str());
+
+        return i;
+    }
+
+    MessageOutput.printf("%s Cannot assign another SPI port to '%s'\r\n", TAG, owner.c_str());
+    return std::nullopt;
+}
+
+void SPIPortManagerClass::freePort(std::string const& owner)
+{
+    for (size_t i = 0; i < _ports.size(); ++i) {
+        if (_ports[i] != owner) { continue; }
+
+        MessageOutput.printf("%s Freeing SPI%d, owner was '%s'\r\n", TAG, i, owner.c_str());
+        _ports[i] = "";
+    }
+}

--- a/src/SPIPortManager.cpp
+++ b/src/SPIPortManager.cpp
@@ -5,23 +5,25 @@
 SPIPortManagerClass SPIPortManager;
 static constexpr char  TAG[] = "[SPIPortManager]";
 
-void SPIPortManagerClass::init() {}
+void SPIPortManagerClass::init() {
+    MessageOutput.printf("%s SPI0 and SPI1 reserved by 'Flash and PSRAM'\r\n", TAG);
+    _ports[0] = "Flash";
+    _ports[1] = "PSRAM";
+}
 
 std::optional<uint8_t> SPIPortManagerClass::allocatePort(std::string const& owner)
 {
     for (size_t i = 0; i < _ports.size(); ++i) {
-        auto spiNum = i + _offset_spi_num;
-
         if (_ports[i] != "") {
-            MessageOutput.printf("%s SPI%d already in use by '%s'\r\n", TAG, spiNum, _ports[i].c_str());
+            MessageOutput.printf("%s SPI%d already in use by '%s'\r\n", TAG, i, _ports[i].c_str());
             continue;
         }
 
         _ports[i] = owner;
 
-        MessageOutput.printf("%s SPI%d now in use by '%s'\r\n", TAG, spiNum, owner.c_str());
+        MessageOutput.printf("%s SPI%d now in use by '%s'\r\n", TAG, i, owner.c_str());
 
-        return spiNum;
+        return i + _offset_spi_num;
     }
 
     MessageOutput.printf("%s Cannot assign another SPI port to '%s'\r\n", TAG, owner.c_str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "Led_Single.h"
 #include "MessageOutput.h"
 #include "SerialPortManager.h"
+#include "SPIPortManager.h"
 #include "VictronMppt.h"
 #include "Battery.h"
 #include "Huawei_can.h"
@@ -97,7 +98,9 @@ void setup()
     const auto& pin = PinMapping.get();
     MessageOutput.println("done");
 
+    // Initialize PortManagers
     SerialPortManager.init();
+    SPIPortManager.init();
 
     // Initialize WiFi
     MessageOutput.print("Initialize Network... ");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,7 @@ void setup()
     Serial.begin(SERIAL_BAUDRATE);
 #if ARDUINO_USB_CDC_ON_BOOT
     Serial.setTxTimeoutMs(0);
-    delay(100);
+    delay(200);
 #else
     while (!Serial)
         yield();


### PR DESCRIPTION
backport 'SPIPortManager' from skippermeisters fork: https://github.com/skippermeister/OpenDTU-OnBattery/commit/a642c9dbdb51d827cb7e709e58272ab682f4f680

Ongoing discussion: https://github.com/helgeerbe/OpenDTU-OnBattery/discussions/1132#discussioncomment-10174002

fixes: https://github.com/helgeerbe/OpenDTU-OnBattery/issues/605

### Tests:
- [x] ESP32 with NRF24 and CMT2300a 
- [x] ESP32 with NRF24 and Huawei CAN
- [x] ESP32 with CMT2300a and Huawei CAN
- [x] ESP32-S3 with NRF24 and CMT2300a 
- [x] ESP32-S3 with NRF24 and Huawei CAN
- [x] ESP32-S3 with CMT2300a and Huawei CAN
~~- [ ] ESP32-C3 with NRF24 and CMT2300a~~
~~- [ ] ESP32-C3 with NRF24 and Huawei CAN~~
~~- [ ] ESP32-C3 with CMT2300a and Huawei CAN~~

### SPI# to SPI ID and SPI_HOST mapping

#### ESP32
 | SPI # | SPI ID | SPI_HOST |
|--|--|--|
| 2     | 2      | 1        |
 | 3     | 3      | 2        |

#### ESP32-S3
| SPI # | SPI ID | SPI_HOST |
|--|--|--|
 | 2     | 0      | 1        |
 | 3     | 1      | 2        |

#### ESP32-C3
| SPI # | SPI ID | SPI_HOST |
|--|--|--|
| 2     | 0      | 1        |