### PR TITLE
webapp: disable OTA firmware dialog for unsupported devices

### DIFF
--- a/include/WebApi_firmware.h
+++ b/include/WebApi_firmware.h
@@ -9,6 +9,9 @@ public:
     void init(AsyncWebServer& server, Scheduler& scheduler);
 
 private:
+    bool otaSupported() const;
+
     void onFirmwareUpdateFinish(AsyncWebServerRequest* request);
     void onFirmwareUpdateUpload(AsyncWebServerRequest* request, String filename, size_t index, uint8_t* data, size_t len, bool final);
+    void onFirmwareStatus(AsyncWebServerRequest* request);
 };

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -766,6 +766,7 @@
     "firmwareupgrade": {
         "FirmwareUpgrade": "Firmware-Aktualisierung",
         "Loading": "@:base.Loading",
+        "NoOtaSupport": "Diese Plattform unterstützt keine OTA-Updates. Neue Firmware kann über die USB-Schnittstelle in den Flash-Speicher geschrieben werden.",
         "OtaError": "OTA-Fehler",
         "Back": "Zurück",
         "Retry": "Wiederholen",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -769,6 +769,7 @@
     "firmwareupgrade": {
         "FirmwareUpgrade": "Firmware Upgrade",
         "Loading": "@:base.Loading",
+        "NoOtaSupport": "This platform does not support OTA updates. New firmware can be written to flash memory using the USB interface.",
         "OtaError": "OTA Error",
         "Back": "Back",
         "Retry": "Retry",

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -742,6 +742,7 @@
     "firmwareupgrade": {
         "FirmwareUpgrade": "Mise à jour du firmware",
         "Loading": "@:base.Loading",
+        "NoOtaSupport": "Cette plateforme ne prend pas en charge les mises à jour OTA. Les nouveaux microprogrammes peuvent être enregistrés dans la mémoire flash à l'aide de l'interface USB.",
         "OtaError": "Erreur OTA",
         "Back": "Retour",
         "Retry": "Réessayer",

--- a/webapp/src/types/FirmwareStatus.ts
+++ b/webapp/src/types/FirmwareStatus.ts
@@ -1,0 +1,3 @@
+export interface FirmwareStatus {
+    ota_supported: boolean;
+}


### PR DESCRIPTION
show a warning in the web UI that OTA updates are not supported, if they are not. this is the case when no second app partition is part of the partitioning scheme, which is determined by the firmware and communicated to the web app.