### PR TITLE
adjust: remove ac-charger target consumption limits

### DIFF
--- a/webapp/src/views/AcChargerAdminView.vue
+++ b/webapp/src/views/AcChargerAdminView.vue
@@ -163,8 +163,6 @@
                                     placeholder="0"
                                     v-model="acChargerConfigList.target_power_consumption"
                                     aria-describedby="targetPowerConsumptionDescription"
-                                    min="-3000"
-                                    max="3000"
                                     required
                                 />
                                 <span class="input-group-text" id="targetPowerConsumptionDescription">W</span>


### PR DESCRIPTION
I don't see any harm by setting crazy numbers to target consumption, so i would say that we let him have it 🤷 

Resolves https://github.com/helgeerbe/OpenDTU-OnBattery/issues/1154

![Screenshot 2024-08-08 at 21 33 25](https://github.com/user-attachments/assets/bdb433f7-e361-46c1-8075-0d070fdde899)
