### PR TITLE
adjustment: reduce precision of charged- and discharged energy for pytes batteries

### DIFF
--- a/src/BatteryStats.cpp
+++ b/src/BatteryStats.cpp
@@ -135,11 +135,11 @@ void PytesBatteryStats::getLiveViewData(JsonVariant& root) const
     addLiveViewValue(root, "availableCapacity", _availableCapacity, "Ah", 0);
 
     if (_chargedEnergy != -1) {
-        addLiveViewValue(root, "chargedEnergy", _chargedEnergy, "kWh", 2);
+        addLiveViewValue(root, "chargedEnergy", _chargedEnergy, "kWh", 1);
     }
 
     if (_dischargedEnergy != -1) {
-        addLiveViewValue(root, "dischargedEnergy", _dischargedEnergy, "kWh", 2);
+        addLiveViewValue(root, "dischargedEnergy", _dischargedEnergy, "kWh", 1);
     }
 
     addLiveViewInSection(root, "cells", "cellMinVoltage", static_cast<float>(_cellMinMilliVolt)/1000, "V", 3);


### PR DESCRIPTION
Precision is reduced to match the CAN protocol definition.

Current:
![Screenshot 2024-08-13 at 13 37 37](https://github.com/user-attachments/assets/3634138b-89f3-4d28-9388-5b667e4226bb)

According to CAN protocol:
![Screenshot 2024-08-13 at 13 40 58](https://github.com/user-attachments/assets/7d913d31-1ff2-4747-9873-634249b7dd6d)
