### PR TITLE
disable "based on OpenDTU" badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,15 +139,18 @@ jobs:
         run: |
           echo "OPEN_DTU_CORE_RELEASE=$(git for-each-ref --sort=creatordate --format '%(refname) %(creatordate)' refs/tags | grep 'refs/tags/v' | tail -1 | sed 's#.*/##' | sed 's/ .*//')" >> $GITHUB_ENV
 
-      - name: Create openDTU-core-release-Badge
-        uses: schneegans/dynamic-badges-action@v1.6.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: 68b47cc8c8994d04ab3a4fa9d8aee5e6
-          filename: openDTUcoreRelease.json
-          label: based on original OpenDTU
-          message: ${{ env.OPEN_DTU_CORE_RELEASE }}
-          color: lightblue
+# disabled as uploading the changed gist failed repeatedly.
+# maybe the token in secrets.GIST_SECRET has expired?
+# need help from repo owner @helgeerbe to fix this.
+#      - name: Create openDTU-core-release-Badge
+#        uses: schneegans/dynamic-badges-action@v1.6.0
+#        with:
+#          auth: ${{ secrets.GIST_SECRET }}
+#          gistID: 68b47cc8c8994d04ab3a4fa9d8aee5e6
+#          filename: openDTUcoreRelease.json
+#          label: based on original OpenDTU
+#          message: ${{ env.OPEN_DTU_CORE_RELEASE }}
+#          color: lightblue
 
       - name: Build Changelog
         id: github_release

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@
 
 This is a fork of [OpenDTU](https://github.com/tbnobody/OpenDTU).
 
+<!---
+disabled while "create release badge" action is broken, see .github/build.yml
 ![GitHub tag (latest SemVer)](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/helgeerbe/68b47cc8c8994d04ab3a4fa9d8aee5e6/raw/openDTUcoreRelease.json)
+--->
 
 [![OpenDTU-OnBattery Build](https://github.com/helgeerbe/OpenDTU-OnBattery/actions/workflows/build.yml/badge.svg)](https://github.com/helgeerbe/OpenDTU-OnBattery/actions/workflows/build.yml)
 [![cpplint](https://github.com/helgeerbe/OpenDTU-OnBattery/actions/workflows/cpplint.yml/badge.svg)](https://github.com/helgeerbe/OpenDTU-OnBattery/actions/workflows/cpplint.yml)


### PR DESCRIPTION
disabled as uploading the changed gist failed repeatedly. maybe the token in secrets.GIST_SECRET has expired? need help from repo owner @helgeerbe to fix this.