### PR TITLE
Fix and improve HttpGetter (HTTP(S) + JSON power meter)

### DIFF
--- a/include/HttpGetter.h
+++ b/include/HttpGetter.h
@@ -9,7 +9,17 @@
 #include <HTTPClient.h>
 #include <WiFiClient.h>
 
-using up_http_client_t = std::unique_ptr<HTTPClient>;
+class HttpGetterClient : public HTTPClient {
+public:
+    void restartTCP() {
+        // keeps the NetworkClient, and closes the TCP connections (as we
+        // effectively do not support keep-alive with HTTP 1.0).
+        HTTPClient::disconnect(true);
+        HTTPClient::connect();
+    }
+};
+
+using up_http_client_t = std::unique_ptr<HttpGetterClient>;
 using sp_wifi_client_t = std::shared_ptr<WiFiClient>;
 
 class HttpRequestResult {

--- a/include/HttpGetter.h
+++ b/include/HttpGetter.h
@@ -69,7 +69,7 @@ public:
     char const* getErrorText() const { return _errBuffer; }
 
 private:
-    std::pair<bool, String> getAuthDigest(String const& authReq, unsigned int counter);
+    std::pair<bool, String> getAuthDigest();
     HttpRequestConfig const& _config;
 
     template<typename... Args>
@@ -80,6 +80,9 @@ private:
     String _host;
     String _uri;
     uint16_t _port;
+
+    String _wwwAuthenticate = "";
+    unsigned _nonceCounter = 0;
 
     sp_wifi_client_t _spWiFiClient; // reused for multiple HTTP requests
 

--- a/include/HttpGetter.h
+++ b/include/HttpGetter.h
@@ -69,7 +69,7 @@ public:
     char const* getErrorText() const { return _errBuffer; }
 
 private:
-    String getAuthDigest(String const& authReq, unsigned int counter);
+    std::pair<bool, String> getAuthDigest(String const& authReq, unsigned int counter);
     HttpRequestConfig const& _config;
 
     template<typename... Args>

--- a/include/PowerMeterHttpJson.h
+++ b/include/PowerMeterHttpJson.h
@@ -42,7 +42,7 @@ private:
     uint32_t _lastPoll = 0;
 
     mutable std::mutex _valueMutex;
-    power_values_t _powerValues;
+    power_values_t _powerValues = {};
 
     std::array<std::unique_ptr<HttpGetter>, POWERMETER_HTTP_JSON_MAX_VALUES> _httpGetters;
 

--- a/src/HttpGetter.cpp
+++ b/src/HttpGetter.cpp
@@ -2,6 +2,7 @@
 #include "HttpGetter.h"
 #include <WiFiClientSecure.h>
 #include "mbedtls/sha256.h"
+#include "mbedtls/md5.h"
 #include <base64.h>
 #include <ESPmDNS.h>
 
@@ -155,8 +156,12 @@ HttpRequestResult HttpGetter::performGetRequest()
             return { false };
         }
         String authReq = upTmpHttpClient->header("WWW-Authenticate");
-        String authorization = getAuthDigest(authReq, 1);
-        upTmpHttpClient->addHeader("Authorization", authorization);
+        auto authorization = getAuthDigest(authReq, 1);
+        if (!authorization.first) {
+            logError("Digest Error: %s", authorization.second.c_str());
+            return { false };
+        }
+        upTmpHttpClient->addHeader("Authorization", authorization.second);
 
         // use a new TCP connection if the server sent "Connection: close".
         bool restart = true;
@@ -183,6 +188,29 @@ HttpRequestResult HttpGetter::performGetRequest()
     return { true, std::move(upTmpHttpClient), _spWiFiClient };
 }
 
+template<size_t binLen>
+static String bin2hex(uint8_t* hash) {
+    size_t constexpr kOutLen = binLen * 2 + 1;
+    char res[kOutLen];
+    for (int i = 0; i < binLen; i++) {
+        snprintf(res + (i*2), sizeof(res) - (i*2), "%02x", hash[i]);
+    }
+    return res;
+}
+
+static String md5(const String& data) {
+    uint8_t hash[16];
+
+    mbedtls_md5_context ctx;
+    mbedtls_md5_init(&ctx);
+    mbedtls_md5_starts_ret(&ctx);
+    mbedtls_md5_update_ret(&ctx, reinterpret_cast<const unsigned char*>(data.c_str()), data.length());
+    mbedtls_md5_finish_ret(&ctx, hash);
+    mbedtls_md5_free(&ctx);
+
+    return bin2hex<sizeof(hash)>(hash);
+}
+
 static String sha256(const String& data) {
     uint8_t hash[32];
 
@@ -193,12 +221,7 @@ static String sha256(const String& data) {
     mbedtls_sha256_finish(&ctx, hash);
     mbedtls_sha256_free(&ctx);
 
-    char res[sizeof(hash) * 2 + 1];
-    for (int i = 0; i < sizeof(hash); i++) {
-        snprintf(res + (i*2), sizeof(res) - (i*2), "%02x", hash[i]);
-    }
-
-    return res;
+    return bin2hex<sizeof(hash)>(hash);
 }
 
 static String extractParam(String const& authReq, String const& param, char delimiter) {
@@ -219,7 +242,22 @@ static String getcNonce(int len) {
     return s;
 }
 
-String HttpGetter::getAuthDigest(String const& authReq, unsigned int counter) {
+static std::pair<bool, String> getAlgo(String const& authReq) {
+    // the algorithm is NOT enclosed in double quotes, so we can't use extractParam
+    auto paramBegin = authReq.indexOf("algorithm=");
+    if (paramBegin == -1) { return { true, "MD5" }; } // default as per RFC2617
+    auto valueBegin = paramBegin + 10;
+
+    String algo = authReq.substring(valueBegin, valueBegin + 3);
+    if (algo == "MD5") { return { true, algo }; }
+
+    algo = authReq.substring(valueBegin, valueBegin + 7);
+    if (algo == "SHA-256") { return { true, algo }; }
+
+    return { false, "unsupported digest algorithm" };
+}
+
+std::pair<bool, String> HttpGetter::getAuthDigest(String const& authReq, unsigned int counter) {
     // extracting required parameters for RFC 2617 Digest
     String realm = extractParam(authReq, "realm=\"", '"');
     String nonce = extractParam(authReq, "nonce=\"", '"');
@@ -228,21 +266,19 @@ String HttpGetter::getAuthDigest(String const& authReq, unsigned int counter) {
     char nc[9];
     snprintf(nc, sizeof(nc), "%08x", counter);
 
-    // sha256 of the user:realm:password
-    String ha1 = sha256(String(_config.Username) + ":" + realm + ":" + _config.Password);
+    auto algo = getAlgo(authReq);
+    if (!algo.first) { return { false, algo.second }; }
 
-    // sha256 of method:uri
-    String ha2 = sha256("GET:" + _uri);
-
-    // sha256 of h1:nonce:nc:cNonce:auth:h2
-    String response = sha256(ha1 + ":" + nonce + ":" + String(nc) +
+    auto hash = (algo.second == "SHA-256") ? &sha256 : &md5;
+    String ha1 = hash(String(_config.Username) + ":" + realm + ":" + _config.Password);
+    String ha2 = hash("GET:" + _uri);
+    String response = hash(ha1 + ":" + nonce + ":" + String(nc) +
             ":" + cNonce + ":" + "auth" + ":" + ha2);
 
-    // Final authorization String
-    return String("Digest username=\"") + _config.Username +
+    return { true, String("Digest username=\"") + _config.Username +
         "\", realm=\"" + realm + "\", nonce=\"" + nonce + "\", uri=\"" +
         _uri + "\", cnonce=\"" + cNonce + "\", nc=" + nc +
-        ", qop=auth, response=\"" + response  + "\", algorithm=SHA-256";
+        ", qop=auth, response=\"" + response  + "\", algorithm=" + algo.second };
 }
 
 void HttpGetter::addHeader(char const* key, char const* value)


### PR DESCRIPTION
A user contacted me on discord (claims s(he) has no Github account) and told me that after upgrading to 2024.08.18, OpenDTU-OnBattery would no longer be able to fetch the power meter value from a Shelly 3 EM. That was a plausible claim as I already expected that the powermeter refactoring would not go without problems.

Even though nobody else came forward, which is strange, I investigated. It turns out that one optimization was illegal (according to HTTP standards): I started reusing the TCP connection to perform the second HTTP GET request after receiving an HTTP 401 (unauthorized) response in a setup with digest authentication. In general this is valid, but if the server sends "Connection: close" one must not reuse the TCP connection to perform any new request.

This is fixed by using the disconnect and connect methods of the HTTPClient. Those are protected for some reason, so I added a shim that derives from HTTPClient and implements a restart method.

The fix was tested against a Shelly 1 PM Mini Gen3 (one of two Shelly's that I have around with no Tasmota yet :grin:).

To test whether "Connection: keep-alive" in a server's response would indeed allow us to reuse the TCP connection I had to implement MD5 digest authentication, so I could test against a local Apache2, which, for whatever fucked-up reason, seems to not implement SHA256 digest authentication. Now we have MD5 digest auth as well, possibly extending the applicability of the HttpGetter for users.

To combat the inherent inefficiency when doing digest authentication and having to not only perform two GET requests (one to get the challenge, another to send a maching Authorization header) but also having to close and re-open a TCP connection, I added caching. The first challenge we receive from the server is cached and each time a new GET request is made, we use the same challenge to calculate a new Authorization header (updated nonce count and a new random client nonce). For every request, we now only need one TCP connection and one HTTP GET request. If the server decides that the previous challenge is expired, it will answer with HTTP401 and we proceed as if we had done the first request to the server and use and cache the new challenge.

Attached are two network traces using the new implementation. The first one shows that even the first transaction does only need one TCP connection as the server supports "Connection: keep-alive" and it uses MD5. The second one shows requests to said Shelly device, using SHA256.

[digest.zip](https://github.com/user-attachments/files/16698302/digest.zip)