### PR TITLE
Allow higher-resolution SoC in live view header

### DIFF
--- a/include/BatteryStats.h
+++ b/include/BatteryStats.h
@@ -18,7 +18,7 @@ class BatteryStats {
         uint32_t getAgeSeconds() const { return (millis() - _lastUpdate) / 1000; }
         bool updateAvailable(uint32_t since) const;
 
-        uint8_t getSoC() const { return _soc; }
+        float getSoC() const { return _soc; }
         uint32_t getSoCAgeSeconds() const { return (millis() - _lastUpdateSoC) / 1000; }
         uint8_t getSoCPrecision() const { return _socPrecision; }
 

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -266,7 +266,7 @@ void PowerLimiterClass::loop()
     _batteryDischargeEnabled = getBatteryPower();
 
     if (_verboseLogging && !config.PowerLimiter.IsInverterSolarPowered) {
-        MessageOutput.printf("[DPL::loop] battery interface %s, SoC: %d %%, StartTH: %d %%, StopTH: %d %%, SoC age: %d s, ignore: %s\r\n",
+        MessageOutput.printf("[DPL::loop] battery interface %s, SoC: %f %%, StartTH: %d %%, StopTH: %d %%, SoC age: %d s, ignore: %s\r\n",
                 (config.Battery.Enabled?"enabled":"disabled"),
                 Battery.getStats()->getSoC(),
                 config.PowerLimiter.BatterySocStartThreshold,

--- a/src/PylontechCanReceiver.cpp
+++ b/src/PylontechCanReceiver.cpp
@@ -31,7 +31,7 @@ void PylontechCanReceiver::onMessage(twai_message_t rx_message)
             _stats->_stateOfHealth = this->readUnsignedInt16(rx_message.data + 2);
 
             if (_verboseLogging) {
-                MessageOutput.printf("[Pylontech] soc: %d soh: %d\r\n",
+                MessageOutput.printf("[Pylontech] soc: %f soh: %d\r\n",
                         _stats->getSoC(), _stats->_stateOfHealth);
             }
             break;

--- a/src/PytesCanReceiver.cpp
+++ b/src/PytesCanReceiver.cpp
@@ -32,7 +32,7 @@ void PytesCanReceiver::onMessage(twai_message_t rx_message)
             _stats->_stateOfHealth = this->readUnsignedInt16(rx_message.data + 2);
 
             if (_verboseLogging) {
-                MessageOutput.printf("[Pytes] soc: %d soh: %d\r\n",
+                MessageOutput.printf("[Pytes] soc: %f soh: %d\r\n",
                         _stats->getSoC(), _stats->_stateOfHealth);
             }
             break;


### PR DESCRIPTION
Commit accc70dea0e4ead2f842f311d393530ad8fa0d55 added the battery SoC to the live view header. But due to getSoC returning an int the precision is currently limited.

This changes getSoC to return float so when a source with higher precision is available the full precision is shown.