### PR TITLE
Add "Victron Smart Battery Sense" to list of battery provider

### DIFF
--- a/include/BatteryStats.h
+++ b/include/BatteryStats.h
@@ -274,11 +274,12 @@ class MqttBatteryStats : public BatteryStats {
 
 class VictronSmartBatterySenseStats : public BatteryStats {
     public:
+        VictronSmartBatterySenseStats() { _manufacturer = "Smart Battery Sense"; };
         void getLiveViewData(JsonVariant& root) const final;
         void mqttPublish() const final;
 
         void updateFrom(uint32_t volt, int32_t temp, uint32_t timeStamp);
 
     private:
-        float _temperature;
+        float _temperature = 0.0f;
 };

--- a/include/BatteryStats.h
+++ b/include/BatteryStats.h
@@ -7,6 +7,7 @@
 #include "Arduino.h"
 #include "JkBmsDataPoints.h"
 #include "VeDirectShuntController.h"
+#include "VictronMppt.h"
 #include <cfloat>
 
 // mandatory interface for all kinds of batteries
@@ -269,4 +270,15 @@ class MqttBatteryStats : public BatteryStats {
         // we don't need a card in the liveview, since the SoC and
         // voltage (if available) is already displayed at the top.
         void getLiveViewData(JsonVariant& root) const final { }
+};
+
+class VictronSmartBatterySenseStats : public BatteryStats {
+    public:
+        void getLiveViewData(JsonVariant& root) const final;
+        void mqttPublish() const final;
+
+        void updateFrom(uint32_t volt, int32_t temp, uint32_t timeStamp);
+
+    private:
+        float _temperature;
 };

--- a/include/VictronSmartBatterySense.h
+++ b/include/VictronSmartBatterySense.h
@@ -5,8 +5,8 @@
 
 class VictronSmartBatterySense : public BatteryProvider {
 public:
-    bool init(bool verboseLogging) final;
-    void deinit() final;
+    bool init(bool verboseLogging) final { return true; };
+    void deinit() final {}; // nothing to deinitialize, we use the MPPT interface
     void loop() final;
     std::shared_ptr<BatteryStats> getStats() const final { return _stats; }
 

--- a/include/VictronSmartBatterySense.h
+++ b/include/VictronSmartBatterySense.h
@@ -11,8 +11,6 @@ public:
     std::shared_ptr<BatteryStats> getStats() const final { return _stats; }
 
 private:
-    // static char constexpr _serialPortOwner[] = "SmartBatterySense";
-
     uint32_t _lastUpdate = 0;
     std::shared_ptr<VictronSmartBatterySenseStats> _stats =
         std::make_shared<VictronSmartBatterySenseStats>();

--- a/include/VictronSmartBatterySense.h
+++ b/include/VictronSmartBatterySense.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include "Battery.h"
+
+class VictronSmartBatterySense : public BatteryProvider {
+public:
+    bool init(bool verboseLogging) final;
+    void deinit() final;
+    void loop() final;
+    std::shared_ptr<BatteryStats> getStats() const final { return _stats; }
+
+private:
+    // static char constexpr _serialPortOwner[] = "SmartBatterySense";
+
+    uint32_t _lastUpdate = 0;
+    std::shared_ptr<VictronSmartBatterySenseStats> _stats =
+        std::make_shared<VictronSmartBatterySenseStats>();
+};

--- a/src/Battery.cpp
+++ b/src/Battery.cpp
@@ -6,6 +6,7 @@
 #include "VictronSmartShunt.h"
 #include "MqttBattery.h"
 #include "PytesCanReceiver.h"
+#include "VictronSmartBatterySense.h"
 
 BatteryClass Battery;
 
@@ -60,6 +61,9 @@ void BatteryClass::updateSettings()
             break;
         case 4:
             _upProvider = std::make_unique<PytesCanReceiver>();
+            break;
+        case 6:
+            _upProvider = std::make_unique<VictronSmartBatterySense>();
             break;
         default:
             MessageOutput.printf("[Battery] Unknown provider: %d\r\n", config.Battery.Provider);

--- a/src/Battery.cpp
+++ b/src/Battery.cpp
@@ -62,7 +62,7 @@ void BatteryClass::updateSettings()
         case 4:
             _upProvider = std::make_unique<PytesCanReceiver>();
             break;
-        case 6:
+        case 5:
             _upProvider = std::make_unique<VictronSmartBatterySense>();
             break;
         default:

--- a/src/BatteryStats.cpp
+++ b/src/BatteryStats.cpp
@@ -7,6 +7,7 @@
 #include "JkBmsDataPoints.h"
 #include "MqttSettings.h"
 
+
 template<typename T>
 static void addLiveViewInSection(JsonVariant& root,
     std::string const& section, std::string const& name,
@@ -610,4 +611,27 @@ void VictronSmartShuntStats::mqttPublish() const {
     MqttSettings.publish("battery/lastFullCharge", String(_lastFullCharge));
     MqttSettings.publish("battery/midpointVoltage", String(_midpointVoltage));
     MqttSettings.publish("battery/midpointDeviation", String(_midpointDeviation));
+}
+
+
+void VictronSmartBatterySenseStats::updateFrom(uint32_t volt, int32_t temp, uint32_t timeStamp) {
+
+    // we just get battery voltage and temperature from the "Smart Battery Sense" device
+    BatteryStats::setVoltage(volt/ 1000.0f, timeStamp);
+    _temperature = temp / 1000.0f;
+}
+
+void VictronSmartBatterySenseStats::getLiveViewData(JsonVariant& root) const {
+
+    // the smart battery sense measures only voltage and temperature
+    root["manufacturer"] = _manufacturer;
+    root["data_age"] = getAgeSeconds();
+
+    // values go into the "Status" card of the web application
+    addLiveViewValue(root, "voltage", getVoltage(), "V", 2);
+    addLiveViewValue(root, "temperature", _temperature, "°C", 1);
+}
+
+void VictronSmartBatterySenseStats::mqttPublish() const {
+    BatteryStats::mqttPublish();
 }

--- a/src/BatteryStats.cpp
+++ b/src/BatteryStats.cpp
@@ -7,7 +7,6 @@
 #include "JkBmsDataPoints.h"
 #include "MqttSettings.h"
 
-
 template<typename T>
 static void addLiveViewInSection(JsonVariant& root,
     std::string const& section, std::string const& name,
@@ -613,13 +612,11 @@ void VictronSmartShuntStats::mqttPublish() const {
     MqttSettings.publish("battery/midpointDeviation", String(_midpointDeviation));
 }
 
-
 void VictronSmartBatterySenseStats::updateFrom(uint32_t volt, int32_t temp, uint32_t timeStamp) {
 
     // we just get battery voltage and temperature from the "Smart Battery Sense" device
     BatteryStats::setVoltage(volt / 1000.0f, timeStamp);
     _temperature = temp / 1000.0f;
-    _manufacturer = "Smart Battery Sense";
 }
 
 void VictronSmartBatterySenseStats::getLiveViewData(JsonVariant& root) const {
@@ -635,4 +632,5 @@ void VictronSmartBatterySenseStats::getLiveViewData(JsonVariant& root) const {
 
 void VictronSmartBatterySenseStats::mqttPublish() const {
     BatteryStats::mqttPublish();
+    MqttSettings.publish("battery/temperature", String(_temperature));
 }

--- a/src/BatteryStats.cpp
+++ b/src/BatteryStats.cpp
@@ -617,8 +617,9 @@ void VictronSmartShuntStats::mqttPublish() const {
 void VictronSmartBatterySenseStats::updateFrom(uint32_t volt, int32_t temp, uint32_t timeStamp) {
 
     // we just get battery voltage and temperature from the "Smart Battery Sense" device
-    BatteryStats::setVoltage(volt/ 1000.0f, timeStamp);
+    BatteryStats::setVoltage(volt / 1000.0f, timeStamp);
     _temperature = temp / 1000.0f;
+    _manufacturer = "Smart Battery Sense";
 }
 
 void VictronSmartBatterySenseStats::getLiveViewData(JsonVariant& root) const {

--- a/src/VictronSmartBatterySense.cpp
+++ b/src/VictronSmartBatterySense.cpp
@@ -3,23 +3,6 @@
 #include "MessageOutput.h"
 #include "VictronSmartBatterySense.h"
 
-void VictronSmartBatterySense::deinit()
-{
-    // nothing to deinitialize, we use the MPPT interface
-    ;
-}
-
-bool VictronSmartBatterySense::init(bool verboseLogging)
-{
-    // we use the existing Victron MPPT interface
-    if (VictronMppt.controllerAmount() > 0) {
-        MessageOutput.println("[VictronSmartBatterySense] Use existing MPPT interface...");
-        return true;
-    } else {
-        MessageOutput.println("[VictronSmartBatterySense] No MPPT interface available...");
-        return false;
-    }
-}
 
 void VictronSmartBatterySense::loop()
 {
@@ -27,18 +10,13 @@ void VictronSmartBatterySense::loop()
     if ((millis() - _lastUpdate) < 1000) { return; }
 
     // if more MPPT are available, we use the fist MPPT with valid smart battery sense data
-    uint32_t volt {0};
-    int32_t temp {0};
     auto idxMax = VictronMppt.controllerAmount();
     for (auto idx = 0; idx < idxMax; ++idx) {
         auto mpptData = VictronMppt.getData(idx);
         if ((mpptData->SmartBatterySenseTemperatureMilliCelsius.first != 0) && (VictronMppt.isDataValid(idx))) {
-            volt = mpptData->batteryVoltage_V_mV;
-            temp = mpptData->SmartBatterySenseTemperatureMilliCelsius.second;
             _lastUpdate = millis() - VictronMppt.getDataAgeMillis(idx);
-            break;
+            _stats->updateFrom(mpptData->batteryVoltage_V_mV, mpptData->SmartBatterySenseTemperatureMilliCelsius.second, _lastUpdate);
+            return;
         }
     }
-
-    _stats->updateFrom(volt, temp, _lastUpdate);
 }

--- a/src/VictronSmartBatterySense.cpp
+++ b/src/VictronSmartBatterySense.cpp
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-
 #include "VictronMppt.h"
 #include "MessageOutput.h"
 #include "VictronSmartBatterySense.h"
@@ -36,10 +35,10 @@ void VictronSmartBatterySense::loop()
         if ((mpptData->SmartBatterySenseTemperatureMilliCelsius.first != 0) && (VictronMppt.isDataValid(idx))) {
             volt = mpptData->batteryVoltage_V_mV;
             temp = mpptData->SmartBatterySenseTemperatureMilliCelsius.second;
-            _lastUpdate = VictronMppt.getDataAgeMillis(idx) + millis();
+            _lastUpdate = millis() - VictronMppt.getDataAgeMillis(idx);
             break;
         }
     }
 
-     _stats->updateFrom(volt, temp, _lastUpdate);
+    _stats->updateFrom(volt, temp, _lastUpdate);
 }

--- a/src/VictronSmartBatterySense.cpp
+++ b/src/VictronSmartBatterySense.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "VictronMppt.h"
+#include "MessageOutput.h"
+#include "VictronSmartBatterySense.h"
+
+void VictronSmartBatterySense::deinit()
+{
+    // nothing to deinitialize, we use the MPPT interface
+    ;
+}
+
+bool VictronSmartBatterySense::init(bool verboseLogging)
+{
+    // we use the existing Victron MPPT interface
+    if (VictronMppt.controllerAmount() > 0) {
+        MessageOutput.println("[VictronSmartBatterySense] Use existing MPPT interface...");
+        return true;
+    } else {
+        MessageOutput.println("[VictronSmartBatterySense] No MPPT interface available...");
+        return false;
+    }
+}
+
+void VictronSmartBatterySense::loop()
+{
+    // data update every second
+    if ((millis() - _lastUpdate) < 1000) { return; }
+
+    // if more MPPT are available, we use the fist MPPT with valid smart battery sense data
+    uint32_t volt {0};
+    int32_t temp {0};
+    auto idxMax = VictronMppt.controllerAmount();
+    for (auto idx = 0; idx < idxMax; ++idx) {
+        auto mpptData = VictronMppt.getData(idx);
+        if ((mpptData->SmartBatterySenseTemperatureMilliCelsius.first != 0) && (VictronMppt.isDataValid(idx))) {
+            volt = mpptData->batteryVoltage_V_mV;
+            temp = mpptData->SmartBatterySenseTemperatureMilliCelsius.second;
+            _lastUpdate = VictronMppt.getDataAgeMillis(idx) + millis();
+            break;
+        }
+    }
+
+     _stats->updateFrom(volt, temp, _lastUpdate);
+}

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -671,7 +671,7 @@
         "ProviderJkBmsSerial": "Jikong (JK) BMS per serieller Verbindung",
         "ProviderMqtt": "Batteriewerte aus MQTT Broker",
         "ProviderVictron": "Victron SmartShunt per VE.Direct Schnittstelle",
-        "ProviderSmartSense": "Victron SmartBatterySense per MPPT Schnittstelle",
+        "ProviderSmartSense": "Victron Smart Battery Sense per VE.Direct charge controller",
         "ProviderPytesCan": "Pytes per CAN-Bus",
         "MqttSocConfiguration": "Einstellungen SoC",
         "MqttVoltageConfiguration": "Einstellungen Spannung",

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -671,6 +671,7 @@
         "ProviderJkBmsSerial": "Jikong (JK) BMS per serieller Verbindung",
         "ProviderMqtt": "Batteriewerte aus MQTT Broker",
         "ProviderVictron": "Victron SmartShunt per VE.Direct Schnittstelle",
+        "ProviderSmartSense": "Victron SmartBatterySense per MPPT Schnittstelle",
         "ProviderPytesCan": "Pytes per CAN-Bus",
         "MqttSocConfiguration": "Einstellungen SoC",
         "MqttVoltageConfiguration": "Einstellungen Spannung",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -673,7 +673,7 @@
         "ProviderJkBmsSerial": "Jikong (JK) BMS using serial connection",
         "ProviderMqtt": "Battery data from MQTT broker",
         "ProviderVictron": "Victron SmartShunt using VE.Direct interface",
-        "ProviderSmartSense": "Victron SmartBatterySense using MPPT interface",
+        "ProviderSmartSense": "Victron Smart Battery Sense via VE.Direct charge controller",
         "ProviderPytesCan": "Pytes using CAN bus",
         "MqttConfiguration": "MQTT Settings",
         "MqttSocConfiguration": "SoC Settings",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -673,6 +673,7 @@
         "ProviderJkBmsSerial": "Jikong (JK) BMS using serial connection",
         "ProviderMqtt": "Battery data from MQTT broker",
         "ProviderVictron": "Victron SmartShunt using VE.Direct interface",
+        "ProviderSmartSense": "Victron SmartBatterySense using MPPT interface",
         "ProviderPytesCan": "Pytes using CAN bus",
         "MqttConfiguration": "MQTT Settings",
         "MqttSocConfiguration": "SoC Settings",

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -598,6 +598,7 @@
         "ProviderJkBmsSerial": "Jikong (JK) BMS using serial connection",
         "ProviderMqtt": "Battery data from MQTT broker",
         "ProviderVictron": "Victron SmartShunt using VE.Direct interface",
+        "ProviderSmartSense": "Victron SmartBatterySense en utilisant une MPPT",
         "MqttSocConfiguration": "SoC Settings",
         "MqttVoltageConfiguration": "Voltage Settings",
         "MqttJsonPath": "Optional: JSON Path",

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -598,7 +598,7 @@
         "ProviderJkBmsSerial": "Jikong (JK) BMS using serial connection",
         "ProviderMqtt": "Battery data from MQTT broker",
         "ProviderVictron": "Victron SmartShunt using VE.Direct interface",
-        "ProviderSmartSense": "Victron SmartBatterySense en utilisant une MPPT",
+        "ProviderSmartSense": "Victron Smart Battery Sense via le VE.Direct charge controller",
         "MqttSocConfiguration": "SoC Settings",
         "MqttVoltageConfiguration": "Voltage Settings",
         "MqttJsonPath": "Optional: JSON Path",

--- a/webapp/src/views/BatteryAdminView.vue
+++ b/webapp/src/views/BatteryAdminView.vue
@@ -155,6 +155,7 @@ export default defineComponent({
                 { key: 1, value: 'JkBmsSerial' },
                 { key: 2, value: 'Mqtt' },
                 { key: 3, value: 'Victron' },
+                { key: 6, value: 'SmartSense' },
                 { key: 4, value: 'PytesCan' },
             ],
             jkBmsInterfaceTypeList: [

--- a/webapp/src/views/BatteryAdminView.vue
+++ b/webapp/src/views/BatteryAdminView.vue
@@ -155,8 +155,8 @@ export default defineComponent({
                 { key: 1, value: 'JkBmsSerial' },
                 { key: 2, value: 'Mqtt' },
                 { key: 3, value: 'Victron' },
-                { key: 6, value: 'SmartSense' },
                 { key: 4, value: 'PytesCan' },
+                { key: 5, value: 'SmartSense' },
             ],
             jkBmsInterfaceTypeList: [
                 { key: 0, value: 'Uart' },


### PR DESCRIPTION
Smart Battery Sense

Endlich kann ich den fehlenden Teil der „Smart Battery Sense“ Integration nachliefen.
Snoopy-HSS hat eine gute Vorlage geliefert.
Thanks @Snoopy-HSS for the blueprint.
Die „Smart Battery Sense“ liefert nur Batterie-Spannung und Batterie-Temperatur. Die Anzeige konnte ich auf diese beiden Werte begrenzen. Das Meldungs Feld konnte ich nicht ausblenden. Vermutlich müsste ich dazu die UI (Java-Script) anfassen und das übersteigt meine Kenntnisse. Von meiner Seite kann man das aber auch so lassen.

Die ID für den Provider habe ich gleich auf 6 gesetzt damit ich mit Snoopy-HSS PR #1199 nicht in Konflikt komme. Er verwendet bereits 5.


Weil du diesen PR vermutlich wegen fehlender Hardware nicht testen kannst, habe ich ein paar Screenshots gemacht.

Aktivieren als Datenanbieter
![grafik](https://github.com/user-attachments/assets/84e9e242-965b-454f-894b-8371d4e75c9d)

Anzeige der Spannung
![grafik](https://github.com/user-attachments/assets/70435b0a-d27b-4706-87be-b5717656bb75)

Anzeige der Daten
![grafik](https://github.com/user-attachments/assets/07bedb79-8768-414d-bbb8-d7b575569941)

Anzeige im Fehlerfall
![grafik](https://github.com/user-attachments/assets/c21d60df-aa24-443b-a4d3-aff204ec1bf5)

Getestet habe ich folgende Fälle:
- Aktivieren und Deaktivieren (Wenn Smart Batterie Sense vorhanden ist)
- Aktivieren und Deaktivieren (Wenn Smart Batterie Sense nicht vorhanden ist)
- Ausfall im laufenden Betrieb (Smart Batterie Sense abstecken)
- Das fehlen von SoC und Batteriestrom führt in anderen Programmteilen zu keinem Problem (Nur im Code überprüft)

Ansonsten fällt mir jetzt auch nichts mehr ein was noch fehlen würde.
Update 03.09.24
- MQTT kann ich nicht testen
- Das aktivieren von "Verbose Logging" macht hier keinen Sinn. Es wird ja die VE.Direct vom MPPT verwendet