### PR TITLE
Sanitize manufacturer name to avoid json errors.

### DIFF
--- a/include/BatteryStats.h
+++ b/include/BatteryStats.h
@@ -67,13 +67,15 @@ class BatteryStats {
             _lastUpdateCurrent = _lastUpdate = timestamp;
         }
 
-        String _manufacturer = "unknown";
+        void setManufacturer(const String& m);
+
         String _hwversion = "";
         String _fwversion = "";
         String _serial = "";
         uint32_t _lastUpdate = 0;
 
     private:
+        String _manufacturer = "unknown";
         uint32_t _lastMqttPublish = 0;
         float _soc = 0;
         uint8_t _socPrecision = 0; // decimal places
@@ -98,7 +100,6 @@ class PylontechBatteryStats : public BatteryStats {
         float getChargeCurrentLimitation() const { return _chargeCurrentLimitation; } ;
 
     private:
-        void setManufacturer(String&& m) { _manufacturer = std::move(m); }
         void setLastUpdate(uint32_t ts) { _lastUpdate = ts; }
 
         float _chargeVoltage;
@@ -137,7 +138,6 @@ class PytesBatteryStats : public BatteryStats {
         float getChargeCurrentLimitation() const { return _chargeCurrentLimit; } ;
 
     private:
-        void setManufacturer(String&& m) { _manufacturer = std::move(m); }
         void setLastUpdate(uint32_t ts) { _lastUpdate = ts; }
         void updateSerial() {
             if (!_serialPart1.isEmpty() && !_serialPart2.isEmpty()) {

--- a/src/PylontechCanReceiver.cpp
+++ b/src/PylontechCanReceiver.cpp
@@ -106,7 +106,7 @@ void PylontechCanReceiver::onMessage(twai_message_t rx_message)
                 MessageOutput.printf("[Pylontech] Manufacturer: %s\r\n", manufacturer.c_str());
             }
 
-            _stats->setManufacturer(std::move(manufacturer));
+            _stats->setManufacturer(manufacturer);
             break;
         }
 

--- a/src/PytesCanReceiver.cpp
+++ b/src/PytesCanReceiver.cpp
@@ -127,7 +127,7 @@ void PytesCanReceiver::onMessage(twai_message_t rx_message)
                 MessageOutput.printf("[Pytes] Manufacturer: %s\r\n", manufacturer.c_str());
             }
 
-            _stats->setManufacturer(std::move(manufacturer));
+            _stats->setManufacturer(manufacturer);
             break;
         }
 


### PR DESCRIPTION
If the string contains control characters for some reason, the browser will reject the json with the error `bad control character in string literal`.

See https://github.com/helgeerbe/OpenDTU-OnBattery/discussions/1226#discussioncomment-10566898