### PR TITLE
Adjust logging of can message identifiers to support extended frames

### DIFF
--- a/src/BatteryCanReceiver.cpp
+++ b/src/BatteryCanReceiver.cpp
@@ -140,7 +140,7 @@ void BatteryCanReceiver::loop()
     }
 
     if (_verboseLogging) {
-        MessageOutput.printf("[%s] Received CAN message: 0x%04X -",
+        MessageOutput.printf("[%s] Received CAN message: 0x%X -",
                 _providerName, rx_message.identifier);
 
         for (int i = 0; i < rx_message.data_length_code; i++) {


### PR DESCRIPTION
So far we only worked with non-extended can message identifiers. In the deye can protocol there are also extended frames with extended identifiers specified. To allow further testing we should log all identifiers in full length.

Logging still looks like the same for pytes with victron protocol.
```
21:22:39.226 > [Pytes] Received CAN message: 0x351 - 10 02 E8 03 FA 00 C7 01
21:22:39.242 > [Pytes] chargeVoltageLimit: 52.799999 chargeCurrentLimit: 100.000000 dischargeCurrentLimit: 25.000000 dischargeVoltageLimit: 45.500000
21:22:39.324 > [Pytes] Received CAN message: 0x355 - 14 00 64 00
21:22:39.353 > [Pytes] soc: 20.000000 soh: 100
21:22:39.392 > [Pytes] Received CAN message: 0x356 - 5E 14 00 00 AA 00
21:22:39.447 > [Pytes] voltage: 52.139999 current: 0.000000 temperature: 17.000000
21:22:39.459 > [Pytes] Received CAN message: 0x35A - 00 00 00 00 00 00 00 00
21:22:39.494 > [Pytes] Alarms: 0 0 0 0 0 0 0 0 0 0
21:22:39.533 > [Pytes] Warnings: 0 0 0 0 0 0 0 0 0 0
21:22:39.548 > [Pytes] Received CAN message: 0x35E - 50 59 54 45 53
21:22:39.606 > [Pytes] Manufacturer: PYTES
21:22:39.642 > [Pytes] Received CAN message: 0x35F - 01 00 16 04 14 00
21:22:39.678 > [Pytes] fwversion: v22.4 availableCapacity: 20.000000 Ah
21:22:39.684 > [Pytes] Received CAN message: 0x360 - 00
21:22:39.686 > [Pytes] chargeImmediately: 0
21:22:39.690 > [Pytes] Received CAN message: 0x372 - 01 00 00 00 00 00 00 00
21:22:39.695 > [Pytes] moduleCountOnline: 1 moduleCountBlockingCharge: 0 moduleCountBlockingDischarge: 0 moduleCountOffline: 0
21:22:39.713 > [Pytes] Received CAN message: 0x373 - BA 0C BD 0C 22 01 22 01
21:22:39.715 > [Pytes] lowestCellMilliVolt: 3258 highestCellMilliVolt: 3261 minimumCellTemperature: 17.000000 maximumCellTemperature: 17.000000
21:22:39.736 > [Pytes] Received CAN message: 0x374 - 30 31 30 30 00 00 00 00
21:22:39.738 > [Pytes] cellMinVoltageName: 0100
21:22:39.738 > [Pytes] Received CAN message: 0x375 - 30 34 30 30 00 00 00 00
21:22:39.739 > [Pytes] cellMaxVoltageName: 0400
21:22:39.739 > [Pytes] Received CAN message: 0x376 - 30 30 30 30 00 00 00 00
21:22:39.744 > [Pytes] cellMinTemperatureName: 0000
21:22:39.747 > [Pytes] Received CAN message: 0x377 - 30 30 30 30 00 00 00 00
21:22:39.754 > [Pytes] cellMaxTemperatureName: 0000
21:22:39.763 > [Pytes] Received CAN message: 0x378 - FD 03 00 00 EC 03 00 00
21:22:39.767 > [Pytes] chargedEnergy: 102.099998 dischargedEnergy: 100.400002
21:22:39.770 > [Pytes] Received CAN message: 0x379 - 64 00
21:22:39.777 > [Pytes] totalCapacity: 100.000000 Ah

```

