### PR TITLE
Increased chunkSizeWarningLimit

### DIFF
--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
     outDir: '../webapp_dist',
     emptyOutDir: true,
     minify: 'terser',
+    chunkSizeWarningLimit: 1024,
     rollupOptions: {
       output: {
         // Only create one js file


### PR DESCRIPTION
Increased `chunkSizeWarningLimit` from 500k (default) to 1024k in order  to get rid of the warning messages. 

As the chunk is always larger than 500k, I assume, this does not hurt and the warning can be silenced