### PR TITLE
Fix: DPL: Ignore assumed solar inverter power when not producing

### DIFF
--- a/include/PowerLimiterInverter.h
+++ b/include/PowerLimiterInverter.h
@@ -40,7 +40,7 @@ public:
     uint16_t getCurrentOutputAcWatts() const;
 
     // this differs from current output power if new limit was assigned
-    uint16_t getExpectedOutputAcWatts() const;
+    virtual uint16_t getExpectedOutputAcWatts() const;
 
     // the maximum reduction of power output the inverter
     // can achieve with or withouth going into standby.

--- a/include/PowerLimiterSolarInverter.h
+++ b/include/PowerLimiterSolarInverter.h
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #pragma once
 
-#include "PowerLimiterOverscalingInverter.h"
+#include <PowerLimiterOverscalingInverter.h>
 
 class PowerLimiterSolarInverter : public PowerLimiterOverscalingInverter {
 public:
     PowerLimiterSolarInverter(bool verboseLogging, PowerLimiterInverterConfig const& config);
 
+    uint16_t getExpectedOutputAcWatts() const final;
     uint16_t getMaxReductionWatts(bool allowStandby) const final;
     uint16_t getMaxIncreaseWatts() const final;
     uint16_t applyReduction(uint16_t reduction, bool allowStandby) final;

--- a/src/PowerLimiterSolarInverter.cpp
+++ b/src/PowerLimiterSolarInverter.cpp
@@ -4,6 +4,21 @@
 PowerLimiterSolarInverter::PowerLimiterSolarInverter(bool verboseLogging, PowerLimiterInverterConfig const& config)
     : PowerLimiterOverscalingInverter(verboseLogging, config) { }
 
+uint16_t PowerLimiterSolarInverter::getExpectedOutputAcWatts() const
+{
+    // We only return the expected output if the inverter is producing.
+    // This is to avoid that solar-powered inverters are counted in with
+    // higher power than they are actually able to produce during a increase,
+    // which can cause the DPL to request less power from the smart-buffer or
+    // battery-powered inverters or even switch them off. This is especially
+    // critical during sunset and sunrise, when solar-powered inverters
+    // become reachable/unreachable a couple of times but can actually not
+    // produce any power at all.
+    if (!isProducing()) { return 0; }
+
+    return PowerLimiterInverter::getExpectedOutputAcWatts();
+}
+
 uint16_t PowerLimiterSolarInverter::getMaxReductionWatts(bool) const
 {
     if (!isEligible()) { return 0; }


### PR DESCRIPTION
Because solar inverters are switching between reachable and unreachable during sunrise and sunset but can not produce any power at all in those situations, we should not include their expected output when they are woken up from standby during increase

### Problem
> 20:38 hat sich der WR mangels Licht abgeschaltet. (also gelb geworden)
Von da an hat der WR vom Akku ein Limit gesetzt bekommen, was etwa nur ein Drittel des eigentlich erforderlichen war.
Mit der Abenddämmerung laut NTP um 20:42 hat der WR vom Akku wieder richtig geregelt.

https://github.com/hoylabs/OpenDTU-OnBattery/discussions/1867#discussioncomment-12962733

- Solar-powered inverter is standing by at 0 W
- DPL is requesting 303 W from it
- We report back that we will cover 303 W using it
- Power of the smart-buffer inverter is reduced

**Immediate result =>** It did not even start producing anything at all, because the sun is almost gone already
**General result/issue ==>** Not enough power produced to match the household consumption until it is 'night' or the solar-powered inverter gets unreachable
```
20:40:04.961 > [DPL] up 343458 s, it is day, next inverter restart at 355504 s (set to 0)
20:40:04.961 > [DPL] targeting 10 W, base load is 200 W, power meter reads 186.5 W (valid)
20:40:04.961 > [DPL] requesting 303 W from 1 solar-powered inverter currently producing 0 W (diff 303 W, hysteresis 6 W)
20:40:04.961 > [DPL] will cover 200 W using 1 solar-powered inverter
20:40:04.961 > [DPL] requesting 103 W from 1 smart-buffer-powered inverter currently producing 126 W (diff -23 W, hysteresis 6 W)
20:40:04.961 > [DPL inverter 114494813553]:
20:40:05.013 >     expected AC power per MPPT 58 W
20:40:05.013 > [DPL] will cover 103 W using 1 smart-buffer-powered inverter
20:40:05.013 > [DPL] battery allowance is 0/0 W DC/AC, solar power is 0/0 W DC/AC, requested are 0 W AC
20:40:05.013 > [DPL inverter 114494813553]:
20:40:05.013 >     smart-buffer-powered, producing 126 W, output included in power meter reading
20:40:05.013 >     lower/current/upper limit: 26/121/800 W, output capability: 800 W
20:40:05.013 >     sending commands enabled, reachable, eligible
20:40:05.013 >     max reduction production/standby: 100/126 W, max increase: 674 W
20:40:05.013 >     target limit/output/state: 103 W (update)/103 W/production, 0 update timeouts
20:40:05.062 >     MPPTs AC power/DC voltage: a: 63 W/47.7 V b: 64 W/47.7 V
20:40:05.062 > [DPL inverter 114494803976]:
20:40:05.062 >     solar-powered, standing by at 0 W, output included in power meter reading
20:40:05.062 >     lower/current/upper limit: 200/200/800 W, output capability: 800 W
20:40:05.062 >     sending commands enabled, reachable, eligible
20:40:05.062 >     max reduction production/standby: 0/0 W, max increase: 200 W
20:40:05.062 >     target limit/output/state: 200 W (update)/200 W/production, 3 update timeouts
20:40:05.062 >     MPPTs AC power/DC voltage: a: 0 W/28.2 V b: 0 W/28.2 V
```

### Confirmation that the fix is working as expected
https://github.com/hoylabs/OpenDTU-OnBattery/discussions/1867#discussioncomment-13032616

- Solar-powered inverter is standing by at 0 W
- DPL is requesting 413 W from it
- We report back that we will cover 0 W using it

**Immediate result =>** It did not even start producing anything at all, because the sun is almost gone already. smart-buffer was able to cover household consumption.
```
20:50:31.687 > [DPL] up 14392 s, it is day, next inverter restart at 25800 s (set to 0)
20:50:31.687 > [DPL] targeting 20 W, base load is 200 W, power meter reads 10.4 W (valid)
20:50:31.687 > [DPL] requesting 413 W from 1 solar-powered inverter currently producing 0 W (diff 413 W, hysteresis 6 W)
20:50:31.687 > [DPL] will cover 0 W using 1 solar-powered inverter
20:50:31.687 > [DPL] requesting 413 W from 1 smart-buffer-powered inverter currently producing 423 W (diff -10 W, hysteresis 6 W)
20:50:31.737 > [DPL inverter 114494813553]:
20:50:31.737 >     expected AC power per MPPT 198 W
20:50:31.737 > [DPL] will cover 413 W using 1 smart-buffer-powered inverter
20:50:31.737 > [DPL] battery allowance is 0/0 W DC/AC, solar power is 0/0 W DC/AC, requested are 0 W AC
20:50:31.737 > [DPL inverter 114494813553]:
20:50:31.737 >     smart-buffer-powered, producing 423 W, output included in power meter reading
20:50:31.737 >     lower/current/upper limit: 26/409/800 W, output capability: 800 W
20:50:31.737 >     sending commands enabled, reachable, eligible
20:50:31.737 >     max reduction production/standby: 397/423 W, max increase: 377 W
20:50:31.830 >     target limit/output/state: 413 W (update)/413 W/production, 0 update timeouts
20:50:31.830 >     MPPTs AC power/DC voltage: a: 210 W/46.5 V b: 213 W/46.6 V
20:50:31.830 > [DPL inverter 114494803976]:
20:50:31.830 >     solar-powered, standing by at 0 W, output included in power meter reading
20:50:31.830 >     lower/current/upper limit: 200/796/800 W, output capability: 800 W
20:50:31.830 >     sending commands enabled, reachable, eligible
20:50:31.830 >     max reduction production/standby: 0/0 W, max increase: 200 W
20:50:31.830 >     target limit/output/state: 200 W (update)/200 W/production, 0 update timeouts
20:50:31.834 >     MPPTs AC power/DC voltage: a: 0 W/27.9 V b: 0 W/28.0 V
```