### PR TITLE
Fix: DPL: inverters disconnected from the grid are non-eligible

### DIFF
--- a/include/PowerLimiterInverter.h
+++ b/include/PowerLimiterInverter.h
@@ -66,6 +66,7 @@ public:
 
     void restart();
 
+    float getGridVoltage() const;
     float getDcVoltage(uint8_t input);
     bool isSendingCommandsEnabled() const { return _spInverter->getEnableCommands(); }
     bool isReachable() const { return _spInverter->isReachable(); }
@@ -86,6 +87,7 @@ public:
         SendingCommandsDisabled,
         MaxOutputUnknown,
         CurrentLimitUnknown,
+        GridDisconnected,
         Eligible,
         Nighttime
     };

--- a/src/PowerLimiterInverter.cpp
+++ b/src/PowerLimiterInverter.cpp
@@ -67,6 +67,10 @@ PowerLimiterInverter::Eligibility PowerLimiterInverter::getEligibility() const
     // to appear in the inverter's event log.
     if (getCurrentLimitWatts() == 0) { return Eligibility::CurrentLimitUnknown; }
 
+    // inverters not connected to the grid are not eligible, as they cannot
+    // produce power.
+    if (getGridVoltage() < 100.0) { return Eligibility::GridDisconnected; }
+
     return Eligibility::Eligible;
 }
 
@@ -328,6 +332,11 @@ void PowerLimiterInverter::restart()
     _spInverter->sendRestartControlRequest();
 }
 
+float PowerLimiterInverter::getGridVoltage() const
+{
+    return _spInverter->Statistics()->getChannelFieldValue(TYPE_AC, CH0, FLD_UAC);
+}
+
 float PowerLimiterInverter::getDcVoltage(uint8_t input)
 {
     return _spInverter->Statistics()->getChannelFieldValue(TYPE_DC,
@@ -360,6 +369,9 @@ void PowerLimiterInverter::debug() const
             break;
         case Eligibility::CurrentLimitUnknown:
             eligibility += " (current limit unknown)";
+            break;
+        case Eligibility::GridDisconnected:
+            eligibility += " (grid disconnected)";
             break;
         case Eligibility::Eligible:
             eligibility = "eligible";


### PR DESCRIPTION
ignoring disconnected inverters is important in order to avoid trying to start inverters which are not connected to the grid. starting them will fail. consecutive failure to start the inverter will eventually lead to a reboot. this has to be avoided. as inverters disconnected from the grid (for whatever reason) cannot participate in producing power to cover the household consumption, it makes sense in general to ignore these inverters.

closes #2037.
closes #2038.

this is a log from my staging rig where I connected and later disconnected the AC cord from the socket:
```
[2025-06-20 20:23:16] D (201824) dynamicPowerLimiter: [Controller] up 201 s, it is day, next inverter restart at 16838 s (set to 1)
[2025-06-20 20:23:16] D (201825) dynamicPowerLimiter: [Controller] battery interface enabled, SoC 83.0 % (ignored), age 0 s (valid)
[2025-06-20 20:23:16] D (201826) dynamicPowerLimiter: [Controller] BMS: 53.43 V, MPPT: -1.00 V, inverter 112182850946: 53.60
[2025-06-20 20:23:16] D (201828) dynamicPowerLimiter: [Controller] battery voltage 53.43 V, load-corrected voltage 53.43 V @ 0 W, factor 0.00030 1/A
[2025-06-20 20:23:16] D (201829) dynamicPowerLimiter: [Controller] battery discharge allowed, start 50.40 V or 45 %, stop 49.00 V or 40 %
[2025-06-20 20:23:16] D (201830) dynamicPowerLimiter: [Controller] start reached, stop NOT reached, solar-passthrough disabled, use at night disabled and dormant
[2025-06-20 20:23:16] D (201832) dynamicPowerLimiter: [Controller] total max AC power is 120 W, conduction losses are 5 %
[2025-06-20 20:23:16] D (201833) dynamicPowerLimiter: [Controller] targeting -20 W, base load is 90 W, power meter reads 29.7 W (valid)
[2025-06-20 20:23:16] D (201834) dynamicPowerLimiter: [Controller] granting 50 W from DC power bus (no battery discharge limit), solar power is 0/0 W DC/AC
[2025-06-20 20:23:16] V (201836) dynamicPowerLimiter: [Inverter 112182850946] State Details
[2025-06-20 20:23:16] V (201837) dynamicPowerLimiter: [Inverter 112182850946]     battery-powered, standing by at 0 W, output included in power meter reading
[2025-06-20 20:23:16] V (201838) dynamicPowerLimiter: [Inverter 112182850946]     lower/current/upper limit: 13/12/120 W, output capability: 400 W
[2025-06-20 20:23:16] V (201839) dynamicPowerLimiter: [Inverter 112182850946]     sending commands enabled, reachable, disqualified (grid disconnected)
[2025-06-20 20:23:16] V (201840) dynamicPowerLimiter: [Inverter 112182850946]     max reduction production/standby: 0/0 W, max increase: 0 W
[2025-06-20 20:23:16] V (201842) dynamicPowerLimiter: [Inverter 112182850946]     target limit/output/state: -1 W (unchanged)/0 W/unchanged, 0 update timeouts
[2025-06-20 20:23:16] V (201843) dynamicPowerLimiter: [Inverter 112182850946]     MPPTs AC power/DC voltage: a: 0 W/53.6 V
[2025-06-20 20:23:16] I (202012) dynamicPowerLimiter: [Controller] waiting for sufficiently recent power meter reading
[2025-06-20 20:23:18] D (204228) dynamicPowerLimiter: [Controller] up 204 s, it is day, next inverter restart at 16838 s (set to 1)
[2025-06-20 20:23:18] D (204229) dynamicPowerLimiter: [Controller] battery interface enabled, SoC 83.0 % (ignored), age 0 s (valid)
[2025-06-20 20:23:18] D (204230) dynamicPowerLimiter: [Controller] BMS: 53.43 V, MPPT: -1.00 V, inverter 112182850946: 53.70
[2025-06-20 20:23:18] D (204232) dynamicPowerLimiter: [Controller] battery voltage 53.43 V, load-corrected voltage 53.43 V @ 0 W, factor 0.00030 1/A
[2025-06-20 20:23:18] D (204233) dynamicPowerLimiter: [Controller] battery discharge allowed, start 50.40 V or 45 %, stop 49.00 V or 40 %
[2025-06-20 20:23:18] D (204234) dynamicPowerLimiter: [Controller] start reached, stop NOT reached, solar-passthrough disabled, use at night disabled and dormant
[2025-06-20 20:23:18] D (204236) dynamicPowerLimiter: [Controller] total max AC power is 120 W, conduction losses are 5 %
[2025-06-20 20:23:18] D (204237) dynamicPowerLimiter: [Controller] targeting -20 W, base load is 90 W, power meter reads 33.0 W (valid)
[2025-06-20 20:23:18] D (204238) dynamicPowerLimiter: [Controller] granting 53 W from DC power bus (no battery discharge limit), solar power is 0/0 W DC/AC
[2025-06-20 20:23:18] D (204239) dynamicPowerLimiter: [Controller] requesting 53 W from 1 battery-powered inverter currently producing 0 W (diff 53 W, hysteresis 5 W)
[2025-06-20 20:23:18] D (204242) dynamicPowerLimiter: [Controller] will cover 53 W using 1 battery-powered inverter
[2025-06-20 20:23:18] V (204243) dynamicPowerLimiter: [Inverter 112182850946] State Details
[2025-06-20 20:23:18] V (204244) dynamicPowerLimiter: [Inverter 112182850946]     battery-powered, standing by at 0 W, output included in power meter reading
[2025-06-20 20:23:18] V (204245) dynamicPowerLimiter: [Inverter 112182850946]     lower/current/upper limit: 13/12/120 W, output capability: 400 W
[2025-06-20 20:23:18] V (204246) dynamicPowerLimiter: [Inverter 112182850946]     sending commands enabled, reachable, eligible
[2025-06-20 20:23:18] V (204247) dynamicPowerLimiter: [Inverter 112182850946]     max reduction production/standby: 0/0 W, max increase: 120 W
[2025-06-20 20:23:18] V (204249) dynamicPowerLimiter: [Inverter 112182850946]     target limit/output/state: 53 W (update)/53 W/production, 0 update timeouts
[2025-06-20 20:23:18] V (204250) dynamicPowerLimiter: [Inverter 112182850946]     MPPTs AC power/DC voltage: a: 0 W/53.7 V
[2025-06-20 20:23:18] I (204251) dynamicPowerLimiter: [Inverter 112182850946] sending limit of 13.2 % (53 W respectively), max output is 400 W
[2025-06-20 20:23:18] I (204257) dynamicPowerLimiter: [Controller] waiting for a start/stop/restart/limit command to complete
[2025-06-20 20:23:21] D (206391) dynamicPowerLimiter: [Inverter 112182850946] limit update succeeded, actual limit is 13.2 % (53 W respectively), effective 2137 ms after update started, requested were 13.2 %




[2025-06-20 20:26:11] D (377176) dynamicPowerLimiter: [Controller] up 377 s, it is day, next inverter restart at 16838 s (set to 1)
[2025-06-20 20:26:11] D (377178) dynamicPowerLimiter: [Controller] battery interface enabled, SoC 84.0 % (ignored), age 0 s (valid)
[2025-06-20 20:26:11] D (377179) dynamicPowerLimiter: [Controller] BMS: 53.39 V, MPPT: -1.00 V, inverter 112182850946: 53.60
[2025-06-20 20:26:11] D (377180) dynamicPowerLimiter: [Controller] battery voltage 53.39 V, load-corrected voltage 53.39 V @ 0 W, factor 0.00030 1/A
[2025-06-20 20:26:11] D (377182) dynamicPowerLimiter: [Controller] battery discharge allowed, start 50.40 V or 45 %, stop 49.00 V or 40 %
[2025-06-20 20:26:11] D (377183) dynamicPowerLimiter: [Controller] start reached, stop NOT reached, solar-passthrough disabled, use at night disabled and dormant
[2025-06-20 20:26:11] D (377184) dynamicPowerLimiter: [Controller] total max AC power is 120 W, conduction losses are 5 %
[2025-06-20 20:26:11] D (377185) dynamicPowerLimiter: [Controller] targeting -20 W, base load is 90 W, power meter reads 37.4 W (valid)
[2025-06-20 20:26:11] D (377187) dynamicPowerLimiter: [Controller] granting 57 W from DC power bus (no battery discharge limit), solar power is 0/0 W DC/AC
[2025-06-20 20:26:11] V (377188) dynamicPowerLimiter: [Inverter 112182850946] State Details
[2025-06-20 20:26:11] V (377189) dynamicPowerLimiter: [Inverter 112182850946]     battery-powered, standing by at 0 W, output included in power meter reading
[2025-06-20 20:26:11] V (377191) dynamicPowerLimiter: [Inverter 112182850946]     lower/current/upper limit: 13/120/120 W, output capability: 400 W
[2025-06-20 20:26:11] V (377192) dynamicPowerLimiter: [Inverter 112182850946]     sending commands enabled, reachable, disqualified (grid disconnected)
[2025-06-20 20:26:11] V (377193) dynamicPowerLimiter: [Inverter 112182850946]     max reduction production/standby: 0/0 W, max increase: 0 W
[2025-06-20 20:26:11] V (377195) dynamicPowerLimiter: [Inverter 112182850946]     target limit/output/state: -1 W (unchanged)/0 W/unchanged, 0 update timeouts
[2025-06-20 20:26:11] V (377196) dynamicPowerLimiter: [Inverter 112182850946]     MPPTs AC power/DC voltage: a: 0 W/53.6 V
[2025-06-20 20:26:12] D (378237) dynamicPowerLimiter: [Controller] up 378 s, it is day, next inverter restart at 16838 s (set to 1)
[2025-06-20 20:26:12] D (378239) dynamicPowerLimiter: [Controller] battery interface enabled, SoC 84.0 % (ignored), age 1 s (valid)
[2025-06-20 20:26:12] D (378240) dynamicPowerLimiter: [Controller] BMS: 53.39 V, MPPT: -1.00 V, inverter 112182850946: 53.60
[2025-06-20 20:26:12] D (378241) dynamicPowerLimiter: [Controller] battery voltage 53.39 V, load-corrected voltage 53.39 V @ 0 W, factor 0.00030 1/A
[2025-06-20 20:26:12] D (378243) dynamicPowerLimiter: [Controller] battery discharge allowed, start 50.40 V or 45 %, stop 49.00 V or 40 %
[2025-06-20 20:26:12] D (378244) dynamicPowerLimiter: [Controller] start reached, stop NOT reached, solar-passthrough disabled, use at night disabled and dormant
[2025-06-20 20:26:12] D (378245) dynamicPowerLimiter: [Controller] total max AC power is 120 W, conduction losses are 5 %
[2025-06-20 20:26:12] D (378246) dynamicPowerLimiter: [Controller] targeting -20 W, base load is 90 W, power meter reads 17.5 W (valid)
[2025-06-20 20:26:12] D (378248) dynamicPowerLimiter: [Controller] granting 38 W from DC power bus (no battery discharge limit), solar power is 0/0 W DC/AC
[2025-06-20 20:26:12] V (378249) dynamicPowerLimiter: [Inverter 112182850946] State Details
[2025-06-20 20:26:12] V (378250) dynamicPowerLimiter: [Inverter 112182850946]     battery-powered, standing by at 0 W, output included in power meter reading
[2025-06-20 20:26:12] V (378252) dynamicPowerLimiter: [Inverter 112182850946]     lower/current/upper limit: 13/120/120 W, output capability: 400 W
[2025-06-20 20:26:12] V (378253) dynamicPowerLimiter: [Inverter 112182850946]     sending commands enabled, reachable, disqualified (grid disconnected)
[2025-06-20 20:26:12] V (378254) dynamicPowerLimiter: [Inverter 112182850946]     max reduction production/standby: 0/0 W, max increase: 0 W
[2025-06-20 20:26:12] V (378256) dynamicPowerLimiter: [Inverter 112182850946]     target limit/output/state: -1 W (unchanged)/0 W/unchanged, 0 update timeouts
[2025-06-20 20:26:12] V (378257) dynamicPowerLimiter: [Inverter 112182850946]     MPPTs AC power/DC voltage: a: 0 W/53.6 V
```