### PR TITLE
DPL: reduce/increase limits based on current AC power to be consistent with DPL logic

### DIFF
--- a/src/PowerLimiterOverscalingInverter.cpp
+++ b/src/PowerLimiterOverscalingInverter.cpp
@@ -44,20 +44,8 @@ uint16_t PowerLimiterOverscalingInverter::applyIncrease(uint16_t increase)
     // do not wake inverter up if it would produce too much power
     if (!isProducing() && _config.LowerPowerLimit > increase) { return 0; }
 
-    uint16_t baseline = getCurrentLimitWatts();
-
-    // when overscaling is in use we must not use the current limit
-    // because it might be scaled.
-    if (overscalingEnabled()) {
-        baseline = getCurrentOutputAcWatts();
-    }
-
-    // inverters in standby can have an arbitrary limit, yet
-    // the baseline is 0 in case we are about to wake it up from standby.
-    if (!isProducing()) { baseline = 0; }
-
     auto actualIncrease = std::min(increase, getMaxIncreaseWatts());
-    setAcOutput(baseline + actualIncrease);
+    setAcOutput(getCurrentOutputAcWatts() + actualIncrease);
     return actualIncrease;
 }
 

--- a/src/PowerLimiterSmartBufferInverter.cpp
+++ b/src/PowerLimiterSmartBufferInverter.cpp
@@ -59,35 +59,29 @@ uint16_t PowerLimiterSmartBufferInverter::applyReduction(uint16_t reduction, boo
 
     if (reduction == 0) { return 0; }
 
-    auto low = std::min(getCurrentLimitWatts(), getCurrentOutputAcWatts());
+    uint16_t currentOutputAcWatts = getCurrentOutputAcWatts();
+
+    auto low = std::min(getCurrentLimitWatts(), currentOutputAcWatts);
     if (low <= _config.LowerPowerLimit) {
         if (allowStandby && _config.AllowStandby) {
             standby();
-            return std::min(reduction, getCurrentOutputAcWatts());
+            return std::min(reduction, currentOutputAcWatts);
         }
         return 0;
     }
 
-    uint16_t baseline = getCurrentLimitWatts();
-
-    // when overscaling is in use we must not use the current limit
-    // because it might be scaled.
-    if (overscalingEnabled()) {
-        baseline = getCurrentOutputAcWatts();
-    }
-
-    if ((baseline - _config.LowerPowerLimit) >= reduction) {
-        setAcOutput(baseline - reduction);
+    if ((currentOutputAcWatts - _config.LowerPowerLimit) >= reduction) {
+        setAcOutput(currentOutputAcWatts - reduction);
         return reduction;
     }
 
     if (allowStandby && _config.AllowStandby) {
         standby();
-        return std::min(reduction, getCurrentOutputAcWatts());
+        return std::min(reduction, currentOutputAcWatts);
     }
 
     setAcOutput(_config.LowerPowerLimit);
-    return getCurrentOutputAcWatts() - _config.LowerPowerLimit;
+    return currentOutputAcWatts - _config.LowerPowerLimit;
 }
 
 uint16_t PowerLimiterSmartBufferInverter::standby()

--- a/src/PowerLimiterSolarInverter.cpp
+++ b/src/PowerLimiterSolarInverter.cpp
@@ -108,21 +108,15 @@ uint16_t PowerLimiterSolarInverter::applyReduction(uint16_t reduction, bool)
 
     if (reduction == 0) { return 0; }
 
-    uint16_t baseline = getCurrentLimitWatts();
+    uint16_t currentOutputAcWatts = getCurrentOutputAcWatts();
 
-    // when overscaling is in use we must not use the current limit
-    // because it might be scaled.
-    if (overscalingEnabled()) {
-        baseline = getCurrentOutputAcWatts();
-    }
-
-    if ((baseline - _config.LowerPowerLimit) >= reduction) {
-        setAcOutput(baseline - reduction);
+    if ((currentOutputAcWatts - _config.LowerPowerLimit) >= reduction) {
+        setAcOutput(currentOutputAcWatts - reduction);
         return reduction;
     }
 
     setAcOutput(_config.LowerPowerLimit);
-    return getCurrentOutputAcWatts() - _config.LowerPowerLimit;
+    return currentOutputAcWatts - _config.LowerPowerLimit;
 }
 
 uint16_t PowerLimiterSolarInverter::standby()


### PR DESCRIPTION
This pull request simplifies the power management logic across multiple inverter classes by removing redundant baseline calculations and directly using the current AC output power. The changes improve code clarity and maintainability while ensuring consistent behavior.

### Code Simplification:

* [`src/PowerLimiterOverscalingInverter.cpp`](diffhunk://#diff-ad1d906f31f8c639a53393ae13fd7cf0f7cf653e4d462a2a422d7de7d08eeee1L47-R48): Removed the `baseline` variable and its associated conditional logic. The `setAcOutput` method now directly uses `getCurrentOutputAcWatts()` to calculate the new AC output after applying an increase.

* [`src/PowerLimiterSmartBufferInverter.cpp`](diffhunk://#diff-00bb12acf67d93dbf811783b0a28e66f1dec92d8bd1403d060bfc7262c0179d6L71-R72): Simplified the reduction logic by removing the `baseline` variable. The condition and `setAcOutput` method now directly reference `getCurrentOutputAcWatts()` for calculations.

* [`src/PowerLimiterSolarInverter.cpp`](diffhunk://#diff-aaba403ac91bb9a3b2aff1e1699a9394d0db5000127de0da13dcbb910be3f24fL111-R112): Streamlined the reduction logic by eliminating the `baseline` variable and directly using `getCurrentOutputAcWatts()` for both the condition and the `setAcOutput` method.

Resolves #2033 