### PR TITLE
undef TAG only in source files

### DIFF
--- a/lib/LogHelper/src/LogHelper.h
+++ b/lib/LogHelper/src/LogHelper.h
@@ -3,8 +3,6 @@
 #include <Arduino.h>
 #include <esp_log.h>
 
-#undef TAG
-
 #define DTU_LOGE(fmt, ...) ESP_LOGE(TAG, "[%s] " fmt, SUBTAG, ##__VA_ARGS__)
 #define DTU_LOGW(fmt, ...) ESP_LOGW(TAG, "[%s] " fmt, SUBTAG, ##__VA_ARGS__)
 #define DTU_LOGI(fmt, ...) ESP_LOGI(TAG, "[%s] " fmt, SUBTAG, ##__VA_ARGS__)

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -40,6 +40,7 @@
 // The name of the record that contains the checksum.
 static constexpr char checksumTagName[] = "CHECKSUM";
 
+#undef TAG
 static const char* TAG = "veDirect";
 #define SUBTAG _logId
 

--- a/lib/VeDirectFrameHandler/VeDirectFrameHexHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHexHandler.cpp
@@ -18,6 +18,7 @@ HexHandler.cpp
 #include "VeDirectFrameHandler.h"
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "veDirect";
 #define SUBTAG _logId
 

--- a/lib/VeDirectFrameHandler/VeDirectMpptController.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectMpptController.cpp
@@ -13,6 +13,7 @@
 
 //#define PROCESS_NETWORK_STATE
 
+#undef TAG
 static const char* TAG = "veDirect";
 #define SUBTAG _logId
 

--- a/src/MqttHandleHuawei.cpp
+++ b/src/MqttHandleHuawei.cpp
@@ -8,6 +8,7 @@
 #include <ctime>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "gridCharger";
 static const char* SUBTAG = "MQTT";
 

--- a/src/MqttHandlePowerLimiter.cpp
+++ b/src/MqttHandlePowerLimiter.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "dynamicPowerLimiter";
 static const char* SUBTAG = "MQTT";
 

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -19,6 +19,7 @@
 #include "SunPosition.h"
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "dynamicPowerLimiter";
 static const char* SUBTAG = "Controller";
 

--- a/src/PowerLimiterInverter.cpp
+++ b/src/PowerLimiterInverter.cpp
@@ -7,6 +7,7 @@
 #include <esp_log.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "dynamicPowerLimiter";
 #define SUBTAG _logPrefix
 

--- a/src/PowerLimiterOverscalingInverter.cpp
+++ b/src/PowerLimiterOverscalingInverter.cpp
@@ -1,6 +1,7 @@
 #include "PowerLimiterOverscalingInverter.h"
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "dynamicPowerLimiter";
 #define SUBTAG _logPrefix
 

--- a/src/battery/CanReceiver.cpp
+++ b/src/battery/CanReceiver.cpp
@@ -4,6 +4,7 @@
 #include <driver/twai.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "battery";
 #define SUBTAG _providerName
 

--- a/src/battery/Controller.cpp
+++ b/src/battery/Controller.cpp
@@ -11,6 +11,7 @@
 #include <Configuration.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "battery";
 static const char* SUBTAG = "Controller";
 

--- a/src/battery/jbdbms/Provider.cpp
+++ b/src/battery/jbdbms/Provider.cpp
@@ -10,6 +10,7 @@
 #include <SerialPortManager.h>
 #include <frozen/map.h>
 
+#undef TAG
 static const char* TAG = "battery";
 static const char* SUBTAG = "JBD BMS";
 

--- a/src/battery/jbdbms/SerialMessage.cpp
+++ b/src/battery/jbdbms/SerialMessage.cpp
@@ -4,6 +4,7 @@
 #include <battery/jbdbms/SerialMessage.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "battery";
 static const char* SUBTAG = "JBD BMS";
 

--- a/src/battery/jkbms/Dummy.cpp
+++ b/src/battery/jkbms/Dummy.cpp
@@ -3,6 +3,7 @@
 #include <battery/jkbms/Dummy.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "battery";
 static const char* SUBTAG = "JK BMS";
 

--- a/src/battery/jkbms/Provider.cpp
+++ b/src/battery/jkbms/Provider.cpp
@@ -8,6 +8,7 @@
 #include <frozen/map.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "battery";
 static const char* SUBTAG = "JK BMS";
 

--- a/src/battery/jkbms/SerialMessage.cpp
+++ b/src/battery/jkbms/SerialMessage.cpp
@@ -2,6 +2,7 @@
 #include <battery/jkbms/SerialMessage.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "battery";
 static const char* SUBTAG = "JK BMS";
 

--- a/src/battery/mqtt/Provider.cpp
+++ b/src/battery/mqtt/Provider.cpp
@@ -5,6 +5,7 @@
 #include <Utils.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "battery";
 static const char* SUBTAG = "MQTT";
 

--- a/src/battery/pylontech/Provider.cpp
+++ b/src/battery/pylontech/Provider.cpp
@@ -5,6 +5,7 @@
 #include <ctime>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "battery";
 static const char* SUBTAG = "Pylontech";
 namespace Batteries::Pylontech {

--- a/src/battery/pytes/Provider.cpp
+++ b/src/battery/pytes/Provider.cpp
@@ -5,6 +5,7 @@
 #include <ctime>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "battery";
 static const char* SUBTAG = "Pytes";
 

--- a/src/battery/sbs/Provider.cpp
+++ b/src/battery/sbs/Provider.cpp
@@ -5,6 +5,7 @@
 #include <ctime>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "battery";
 static const char* SUBTAG = "SBS";
 

--- a/src/battery/victronsmartshunt/Provider.cpp
+++ b/src/battery/victronsmartshunt/Provider.cpp
@@ -4,6 +4,7 @@
 #include <SerialPortManager.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "battery";
 static const char* SUBTAG = "SmartShunt";
 

--- a/src/battery/zendure/Provider.cpp
+++ b/src/battery/zendure/Provider.cpp
@@ -6,6 +6,7 @@
 #include <Utils.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "battery";
 static const char* SUBTAG = "Zendure";
 

--- a/src/gridcharger/huawei/Controller.cpp
+++ b/src/gridcharger/huawei/Controller.cpp
@@ -11,6 +11,7 @@
 #include "Configuration.h"
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "gridCharger";
 static const char* SUBTAG = "Controller";
 

--- a/src/gridcharger/huawei/HardwareInterface.cpp
+++ b/src/gridcharger/huawei/HardwareInterface.cpp
@@ -6,6 +6,7 @@
 #include <LogHelper.h>
 #include <sstream>
 
+#undef TAG
 static const char* TAG = "gridCharger";
 static const char* SUBTAG = "HwIfc";
 

--- a/src/gridcharger/huawei/MCP2515.cpp
+++ b/src/gridcharger/huawei/MCP2515.cpp
@@ -7,6 +7,7 @@
 #include "Configuration.h"
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "gridCharger";
 static const char* SUBTAG = "MCP2515";
 

--- a/src/gridcharger/huawei/TWAI.cpp
+++ b/src/gridcharger/huawei/TWAI.cpp
@@ -7,6 +7,7 @@
 #include <driver/twai.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "gridCharger";
 static const char* SUBTAG = "TWAI";
 

--- a/src/powermeter/json/http/Provider.cpp
+++ b/src/powermeter/json/http/Provider.cpp
@@ -8,6 +8,7 @@
 #include <ESPmDNS.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "powerMeter";
 static const char* SUBTAG = "HTTP/JSON";
 

--- a/src/powermeter/json/mqtt/Provider.cpp
+++ b/src/powermeter/json/mqtt/Provider.cpp
@@ -5,6 +5,7 @@
 #include <Utils.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "powerMeter";
 static const char* SUBTAG = "MQTT";
 

--- a/src/powermeter/sdm/serial/Provider.cpp
+++ b/src/powermeter/sdm/serial/Provider.cpp
@@ -3,6 +3,7 @@
 #include <PinMapping.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "powerMeter";
 static const char* SUBTAG = "SDM";
 

--- a/src/powermeter/sml/Provider.cpp
+++ b/src/powermeter/sml/Provider.cpp
@@ -2,6 +2,7 @@
 #include <powermeter/sml/Provider.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "powerMeter";
 #define SUBTAG _user
 

--- a/src/powermeter/sml/http/Provider.cpp
+++ b/src/powermeter/sml/http/Provider.cpp
@@ -5,6 +5,7 @@
 #include <ESPmDNS.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "powerMeter";
 static const char* SUBTAG = "HTTP/SML";
 

--- a/src/powermeter/sml/serial/Provider.cpp
+++ b/src/powermeter/sml/serial/Provider.cpp
@@ -3,6 +3,7 @@
 #include <PinMapping.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "powerMeter";
 static const char* SUBTAG = "Serial/SML";
 

--- a/src/powermeter/udp/smahm/Provider.cpp
+++ b/src/powermeter/udp/smahm/Provider.cpp
@@ -7,6 +7,7 @@
 #include <WiFiUdp.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "powerMeter";
 static const char* SUBTAG = "UDP/SMAHM";
 

--- a/src/powermeter/udp/victron/Provider.cpp
+++ b/src/powermeter/udp/victron/Provider.cpp
@@ -7,6 +7,7 @@
 #include <WiFiUdp.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "powerMeter";
 static const char* SUBTAG = "ModbusUDP/Victron";
 

--- a/src/solarcharger/Controller.cpp
+++ b/src/solarcharger/Controller.cpp
@@ -7,6 +7,7 @@
 #include <solarcharger/mqtt/Provider.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "solarCharger";
 static const char* SUBTAG = "Controller";
 

--- a/src/solarcharger/mqtt/Provider.cpp
+++ b/src/solarcharger/mqtt/Provider.cpp
@@ -5,6 +5,7 @@
 #include <Utils.h>
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "solarCharger";
 static const char* SUBTAG = "MQTT";
 

--- a/src/solarcharger/victron/Provider.cpp
+++ b/src/solarcharger/victron/Provider.cpp
@@ -5,6 +5,7 @@
 #include "SerialPortManager.h"
 #include <LogHelper.h>
 
+#undef TAG
 static const char* TAG = "solarCharger";
 static const char* SUBTAG = "VE.Direct";
 


### PR DESCRIPTION
we must not un-define TAG in a header file which is (possibly) included before other header files, as those still might want to use the ESP-IDF LOG* macros, which rely on TAG being a symbol. instead, we #undef TAG right before we set our own symbol (a static const char*).

this fixes a compilation issue where the use of newer versions of async tcp and async webserver would otherwise break.