### PR TITLE
DPL: reduce power based on limit when ac ouput is higher than limit

### DIFF
--- a/src/PowerLimiterSmartBufferInverter.cpp
+++ b/src/PowerLimiterSmartBufferInverter.cpp
@@ -60,8 +60,9 @@ uint16_t PowerLimiterSmartBufferInverter::applyReduction(uint16_t reduction, boo
     if (reduction == 0) { return 0; }
 
     uint16_t currentOutputAcWatts = getCurrentOutputAcWatts();
+    uint16_t currentLimitWatts = getCurrentLimitWatts();
 
-    auto low = std::min(getCurrentLimitWatts(), currentOutputAcWatts);
+    auto low = std::min(currentLimitWatts, currentOutputAcWatts);
     if (low <= _config.LowerPowerLimit) {
         if (allowStandby && _config.AllowStandby) {
             standby();
@@ -70,8 +71,15 @@ uint16_t PowerLimiterSmartBufferInverter::applyReduction(uint16_t reduction, boo
         return 0;
     }
 
-    if ((currentOutputAcWatts - _config.LowerPowerLimit) >= reduction) {
-        setAcOutput(currentOutputAcWatts - reduction);
+    uint16_t baseline = currentOutputAcWatts;
+
+    // when the output is higher than the limit, we must use the limit as the baseline
+    if (currentOutputAcWatts > currentLimitWatts) {
+        baseline = currentLimitWatts;
+    }
+
+    if ((baseline - _config.LowerPowerLimit) >= reduction) {
+        setAcOutput(baseline - reduction);
         return reduction;
     }
 

--- a/src/PowerLimiterSolarInverter.cpp
+++ b/src/PowerLimiterSolarInverter.cpp
@@ -109,9 +109,16 @@ uint16_t PowerLimiterSolarInverter::applyReduction(uint16_t reduction, bool)
     if (reduction == 0) { return 0; }
 
     uint16_t currentOutputAcWatts = getCurrentOutputAcWatts();
+    uint16_t currentLimitWatts = getCurrentLimitWatts();
+    uint16_t baseline = currentOutputAcWatts;
 
-    if ((currentOutputAcWatts - _config.LowerPowerLimit) >= reduction) {
-        setAcOutput(currentOutputAcWatts - reduction);
+    // when the output is higher than the limit, we must use the limit as the baseline
+    if (currentOutputAcWatts > currentLimitWatts) {
+        baseline = currentLimitWatts;
+    }
+
+    if ((baseline - _config.LowerPowerLimit) >= reduction) {
+        setAcOutput(baseline - reduction);
         return reduction;
     }
 


### PR DESCRIPTION
Fixes https://github.com/hoylabs/OpenDTU-OnBattery/issues/2271

This pull request updates the logic for applying power reduction in both the smart buffer inverter and solar inverter classes. The main improvement is that reductions are now calculated using the lower of the current output or the current limit as the baseline, ensuring output never exceeds configured limits after reduction.

**Power reduction logic improvements:**

* In both `PowerLimiterSmartBufferInverter::applyReduction` and `PowerLimiterSolarInverter::applyReduction`, the baseline for reduction is now set to the lower of the current output or the current limit, preventing output from exceeding the allowed limit after a reduction. [[1]](diffhunk://#diff-00bb12acf67d93dbf811783b0a28e66f1dec92d8bd1403d060bfc7262c0179d6L73-R82) [[2]](diffhunk://#diff-aaba403ac91bb9a3b2aff1e1699a9394d0db5000127de0da13dcbb910be3f24fR112-R121)
* Introduced a local variable `currentLimitWatts` in both methods for clarity and to avoid repeated function calls. [[1]](diffhunk://#diff-00bb12acf67d93dbf811783b0a28e66f1dec92d8bd1403d060bfc7262c0179d6R63-R65) [[2]](diffhunk://#diff-aaba403ac91bb9a3b2aff1e1699a9394d0db5000127de0da13dcbb910be3f24fR112-R121)