### PR TITLE
Feature: detect, store and show last Battery Fully Charged Time

### DIFF
--- a/include/RuntimeData.h
+++ b/include/RuntimeData.h
@@ -18,7 +18,7 @@ public:
 
     void init(Scheduler& scheduler);
     bool read(void);
-    bool write(uint16_t const freezeTime);
+    bool write(uint16_t const freezeMinutes = 10); // do not write if last write operation was less than freezeMinutes ago
 
     uint16_t getWriteCount(void) const;
     time_t getWriteEpochTime(void) const;

--- a/include/RuntimeData.h
+++ b/include/RuntimeData.h
@@ -19,6 +19,7 @@ public:
     void init(Scheduler& scheduler);
     bool read(void);
     bool write(uint16_t const freezeMinutes = 10); // do not write if last write operation was less than freezeMinutes ago
+    void requestWriteOnNextTaskLoop(void) { _writeNow = true; }; // use this member function to store data on demand
 
     uint16_t getWriteCount(void) const;
     time_t getWriteEpochTime(void) const;
@@ -33,6 +34,7 @@ private:
     Task _loopTask;
     std::atomic<bool> _readOK = false;      // true if the last read operation was successful
     std::atomic<bool> _writeOK = false;     // true if the last write operation was successful
+    std::atomic<bool> _writeNow = false;    // if true, the data is stored in the next loop()
     mutable std::mutex _mutex;              // to protect the shared data below
     bool _lastTrigger = false;              // auxiliary value to prevent multiple triggering on the same day
     uint16_t _writeVersion = 0;             // shared data: version of the runtime data

--- a/include/RuntimeData.h
+++ b/include/RuntimeData.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <ArduinoJson.h>
+#include <TaskSchedulerDeclarations.h>
+#include <mutex>
+#include <atomic>
+
+
+class RuntimeClass {
+public:
+    explicit RuntimeClass(uint16_t version) : _writeVersion(version) {};
+    ~RuntimeClass() = default;
+    RuntimeClass(const RuntimeClass&) = delete;
+    RuntimeClass& operator=(const RuntimeClass&) = delete;
+    RuntimeClass(RuntimeClass&&) = delete;
+    RuntimeClass& operator=(RuntimeClass&&) = delete;
+
+    void init(Scheduler& scheduler);
+    bool read(void);
+    bool write(void);
+
+    uint16_t getWriteCount(void) const;
+    time_t getWriteEpochTime(void) const;
+    bool getReadState(void) const { return _readOK; }
+    bool getWriteState(void) const { return _writeOK; }
+    String getWriteCountAndTimeString(void) const;
+
+private:
+    void loop(void);
+    bool getWriteTrigger(void) const;
+
+    Task _loopTask;
+    std::atomic<bool> _readOK = false;      // true if the last read/write operation was successful
+    std::atomic<bool> _writeOK = false;     // true if the last read/write operation was successful
+    mutable std::mutex _mutex;              // to protect the shared data below
+    uint16_t _writeVersion = 0;             // shared data: version of the runtime data
+    uint16_t _writeCount = 0;               // shared data: number of times the data was written
+    time_t _writeEpoch = 0;                 // shared data: epoch time when the data was written
+};
+
+extern RuntimeClass RuntimeData;

--- a/include/RuntimeData.h
+++ b/include/RuntimeData.h
@@ -18,7 +18,7 @@ public:
 
     void init(Scheduler& scheduler);
     bool read(void);
-    bool write(void);
+    bool write(uint16_t const freezeTime);
 
     uint16_t getWriteCount(void) const;
     time_t getWriteEpochTime(void) const;

--- a/include/RuntimeData.h
+++ b/include/RuntimeData.h
@@ -28,14 +28,15 @@ public:
 
 private:
     void loop(void);
-    bool getWriteTrigger(void) const;
+    bool getWriteTrigger(void);
 
     Task _loopTask;
-    std::atomic<bool> _readOK = false;      // true if the last read/write operation was successful
-    std::atomic<bool> _writeOK = false;     // true if the last read/write operation was successful
+    std::atomic<bool> _readOK = false;      // true if the last read operation was successful
+    std::atomic<bool> _writeOK = false;     // true if the last write operation was successful
     mutable std::mutex _mutex;              // to protect the shared data below
+    bool _lastTrigger = false;              // auxiliary value to prevent multiple triggering on the same day
     uint16_t _writeVersion = 0;             // shared data: version of the runtime data
-    uint16_t _writeCount = 0;               // shared data: number of times the data was written
+    uint16_t _writeCount = 0;               // shared data: number of write operations
     time_t _writeEpoch = 0;                 // shared data: epoch time when the data was written
 };
 

--- a/include/battery/Controller.h
+++ b/include/battery/Controller.h
@@ -16,6 +16,9 @@ public:
 
     float getDischargeCurrentLimit();
 
+    void serializeRTD(JsonObject const&) const;
+    void deserializeRTD(JsonObject const&);
+
     std::shared_ptr<Stats const> getStats() const;
 
 private:

--- a/include/battery/Provider.h
+++ b/include/battery/Provider.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 namespace Batteries {
 
@@ -15,7 +16,7 @@ public:
     virtual void deinit() = 0;
     virtual void loop() = 0;
     virtual std::shared_ptr<Stats> getStats() const = 0;
-    virtual std::shared_ptr<Stats> getStatsForWrite() = 0;
+    virtual void setFullyChargedEpoch(std::optional<time_t>) = 0;
     virtual std::shared_ptr<HassIntegration> getHassIntegration() = 0;
 };
 

--- a/include/battery/Provider.h
+++ b/include/battery/Provider.h
@@ -15,7 +15,7 @@ public:
     virtual void deinit() = 0;
     virtual void loop() = 0;
     virtual std::shared_ptr<Stats> getStats() const = 0;
-    virtual std::shared_ptr<Stats> setStats() = 0;
+    virtual std::shared_ptr<Stats> getStatsForWrite() = 0;
     virtual std::shared_ptr<HassIntegration> getHassIntegration() = 0;
 };
 

--- a/include/battery/Provider.h
+++ b/include/battery/Provider.h
@@ -15,6 +15,7 @@ public:
     virtual void deinit() = 0;
     virtual void loop() = 0;
     virtual std::shared_ptr<Stats> getStats() const = 0;
+    virtual std::shared_ptr<Stats> setStats() = 0;
     virtual std::shared_ptr<HassIntegration> getHassIntegration() = 0;
 };
 

--- a/include/battery/Stats.h
+++ b/include/battery/Stats.h
@@ -35,9 +35,9 @@ public:
     float getChargeCurrentLimit() const { return _chargeCurrentLimit; };
     uint32_t getChargeCurrentLimitAgeSeconds() const { return (millis() - _lastUpdateChargeCurrentLimit) / 1000; }
 
-    std::optional<time_t> getFullyChargedTime() const { return _oSoCFullTime; }
-    void setFullyChargedTime(std::optional<time_t> full) { _oSoCFullTime = full; }
-    virtual void checkFullyChargedTime(void);
+    std::optional<time_t> getSoCFullEpoch() const { return _oSoCFullEpoch; }
+    void setSoCFullEpoch(std::optional<time_t> full) { _oSoCFullEpoch = full; }
+    virtual void checkSoCFullEpoch(void);
 
     // convert stats to JSON for web application live view
     virtual void getLiveViewData(JsonVariant& root) const;
@@ -179,7 +179,7 @@ private:
     uint32_t _lastMqttPublish = 0;
     float _soc = 0;
     uint8_t _socPrecision = 0; // decimal places
-    std::optional<time_t> _oSoCFullTime = std::nullopt;
+    std::optional<time_t> _oSoCFullEpoch = std::nullopt;
     uint32_t _lastUpdateSoC = 0;
     float _voltage = 0; // total battery pack voltage
     uint32_t _lastUpdateVoltage = 0;

--- a/include/battery/Stats.h
+++ b/include/battery/Stats.h
@@ -35,6 +35,10 @@ public:
     float getChargeCurrentLimit() const { return _chargeCurrentLimit; };
     uint32_t getChargeCurrentLimitAgeSeconds() const { return (millis() - _lastUpdateChargeCurrentLimit) / 1000; }
 
+    std::optional<time_t> getFullyChargedTime() const { return _oSoCFullTime; }
+    void setFullyChargedTime(std::optional<time_t> full) { _oSoCFullTime = full; }
+    virtual void checkFullyChargedTime(void);
+
     // convert stats to JSON for web application live view
     virtual void getLiveViewData(JsonVariant& root) const;
 
@@ -175,6 +179,7 @@ private:
     uint32_t _lastMqttPublish = 0;
     float _soc = 0;
     uint8_t _socPrecision = 0; // decimal places
+    std::optional<time_t> _oSoCFullTime = std::nullopt;
     uint32_t _lastUpdateSoC = 0;
     float _voltage = 0; // total battery pack voltage
     uint32_t _lastUpdateVoltage = 0;

--- a/include/battery/jbdbms/Provider.h
+++ b/include/battery/jbdbms/Provider.h
@@ -20,7 +20,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/jbdbms/Provider.h
+++ b/include/battery/jbdbms/Provider.h
@@ -20,6 +20,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/jbdbms/Provider.h
+++ b/include/battery/jbdbms/Provider.h
@@ -20,7 +20,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/jkbms/Provider.h
+++ b/include/battery/jkbms/Provider.h
@@ -23,6 +23,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/jkbms/Provider.h
+++ b/include/battery/jkbms/Provider.h
@@ -23,7 +23,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/jkbms/Provider.h
+++ b/include/battery/jkbms/Provider.h
@@ -23,7 +23,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/mqtt/Provider.h
+++ b/include/battery/mqtt/Provider.h
@@ -15,6 +15,7 @@ public:
     void deinit() final;
     void loop() final { return; } // this class is event-driven
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
     std::shared_ptr<HassIntegration> getHassIntegration() final { return nullptr; }
 
 private:

--- a/include/battery/mqtt/Provider.h
+++ b/include/battery/mqtt/Provider.h
@@ -15,7 +15,7 @@ public:
     void deinit() final;
     void loop() final { return; } // this class is event-driven
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<HassIntegration> getHassIntegration() final { return nullptr; }
 
 private:

--- a/include/battery/mqtt/Provider.h
+++ b/include/battery/mqtt/Provider.h
@@ -15,7 +15,7 @@ public:
     void deinit() final;
     void loop() final { return; } // this class is event-driven
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
     std::shared_ptr<HassIntegration> getHassIntegration() final { return nullptr; }
 
 private:

--- a/include/battery/pylontech/Provider.h
+++ b/include/battery/pylontech/Provider.h
@@ -16,6 +16,7 @@ public:
     void onMessage(twai_message_t rx_message) final;
 
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/pylontech/Provider.h
+++ b/include/battery/pylontech/Provider.h
@@ -16,7 +16,7 @@ public:
     void onMessage(twai_message_t rx_message) final;
 
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/pylontech/Provider.h
+++ b/include/battery/pylontech/Provider.h
@@ -16,7 +16,7 @@ public:
     void onMessage(twai_message_t rx_message) final;
 
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/pytes/Provider.h
+++ b/include/battery/pytes/Provider.h
@@ -16,6 +16,7 @@ public:
     void onMessage(twai_message_t rx_message) final;
 
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/pytes/Provider.h
+++ b/include/battery/pytes/Provider.h
@@ -16,7 +16,7 @@ public:
     void onMessage(twai_message_t rx_message) final;
 
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/pytes/Provider.h
+++ b/include/battery/pytes/Provider.h
@@ -16,7 +16,7 @@ public:
     void onMessage(twai_message_t rx_message) final;
 
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/sbs/Provider.h
+++ b/include/battery/sbs/Provider.h
@@ -16,6 +16,7 @@ public:
     void onMessage(twai_message_t rx_message) final;
 
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/sbs/Provider.h
+++ b/include/battery/sbs/Provider.h
@@ -16,7 +16,7 @@ public:
     void onMessage(twai_message_t rx_message) final;
 
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/sbs/Provider.h
+++ b/include/battery/sbs/Provider.h
@@ -16,7 +16,7 @@ public:
     void onMessage(twai_message_t rx_message) final;
 
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/victronsmartshunt/Provider.h
+++ b/include/battery/victronsmartshunt/Provider.h
@@ -15,7 +15,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/victronsmartshunt/Provider.h
+++ b/include/battery/victronsmartshunt/Provider.h
@@ -15,7 +15,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/victronsmartshunt/Provider.h
+++ b/include/battery/victronsmartshunt/Provider.h
@@ -15,6 +15,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/victronsmartshunt/Stats.h
+++ b/include/battery/victronsmartshunt/Stats.h
@@ -12,6 +12,7 @@ public:
     void mqttPublish() const final;
 
     void updateFrom(VeDirectShuntController::data_t const& shuntData);
+    void checkFullyChargedTime(void) final;
 
 private:
     float _temperature;

--- a/include/battery/victronsmartshunt/Stats.h
+++ b/include/battery/victronsmartshunt/Stats.h
@@ -12,7 +12,7 @@ public:
     void mqttPublish() const final;
 
     void updateFrom(VeDirectShuntController::data_t const& shuntData);
-    void checkFullyChargedTime(void) final;
+    void checkSoCFullEpoch(void) final;
 
 private:
     float _temperature;

--- a/include/battery/zendure/Provider.h
+++ b/include/battery/zendure/Provider.h
@@ -17,7 +17,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/zendure/Provider.h
+++ b/include/battery/zendure/Provider.h
@@ -17,7 +17,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
-    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> getStatsForWrite() final { return _stats; }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/zendure/Provider.h
+++ b/include/battery/zendure/Provider.h
@@ -17,6 +17,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    std::shared_ptr<::Batteries::Stats> setStats() final { return _stats; }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -6,11 +6,13 @@
  * - The data is stored in JSON format
  * - The data is written during WebApp 'OTA firmware upgrade' and during Webapp 'Reboot'
  * - For security reasons such as 'unexpected power cycles' or 'physical resets', data is also written once a day at 00:05
- * - The data will not be written if the last write operation was less than one hour ago.
+ * - The data will not be written if the last write operation was less than one hour ago. ('OTA firmware upgrade' and 'Reboot')
  * - Threadsave access to the data is provided by a mutex.
  *
- * Note: Runtime data must be added in the read() and write() methods.
- *       To avoid reenter deadlocks, do not call write() or read() from a locally locked mutex to save local data on demand!
+ * How to use:
+ *  - Runtime data must be added in the read() and write() methods.
+ *  - To avoid reenter deadlocks, do not call write() or read() from a locally locked mutex to save locally data on demand!
+ *  - Use requestWriteOnNextTaskLoop() to avoid deadlocks if you want to save locally data on demand.
  *
  * 2025.09.11 - 1.0 - first version
  */
@@ -51,8 +53,12 @@ void RuntimeClass::init(Scheduler& scheduler)
  */
 void RuntimeClass::loop(void)
 {
-    // check whether it is time to write the runtime data but do not write if last write operation was less than 60 min ago
-    if (getWriteTrigger()) { write(60); }
+
+    // check if we need to write the runtime data, either it is 00:05 or on request
+    if (_writeNow || getWriteTrigger()) {
+        _writeNow = false;
+        write(0); // no freeze time.
+    }
 }
 
 
@@ -77,45 +83,46 @@ bool RuntimeClass::write(uint16_t const freezeMinutes)
     if (!Utils::getEpoch(&nextEpoch, 5)) { return cleanExit(false, "Local time not available, skipping write"); }
     uint16_t nextCount;
 
-    { // prepare the next write count
+    {
         std::lock_guard<std::mutex> lock(_mutex);
 
-        // we do not write more than once in a hour
+        // check minimum interval between writes (enforced only when freezeMinutes > 0)
         if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeMinutes)) {
             return cleanExit(false, "Time interval between 2 write operations too short, skipping write");
         }
+
+        // prepare the next write count
         nextCount = _writeCount + 1;
-    } // mutex is automatically released when lock goes out of this scope
 
-    JsonDocument doc;
-    JsonObject info = doc["info"].to<JsonObject>();
-    info["version"] = RUNTIME_VERSION;
-    info["save_count"] = nextCount;
-    info["save_epoch"] = nextEpoch;
+        JsonDocument doc;
+        JsonObject info = doc["info"].to<JsonObject>();
+        info["version"] = RUNTIME_VERSION;
+        info["save_count"] = nextCount;
+        info["save_epoch"] = nextEpoch;
 
-    // Insert additional runtime data here and protect the shared data with a local mutex
-
+        // Insert additional runtime data here and protect the shared data with a local mutex
 
 
-    if (!Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
-        return cleanExit(false, "JSON alloc fault, skipping write");
-    }
 
-    File fRuntime = LittleFS.open(RUNTIME_FILENAME, "w");
-    if (!fRuntime) { return cleanExit(false, "Failed to open file for writing"); }
+        if (!Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
+            return cleanExit(false, "JSON alloc fault, skipping write");
+        }
 
-    if (serializeJson(doc, fRuntime) == 0) {
+        File fRuntime = LittleFS.open(RUNTIME_FILENAME, "w");
+        if (!fRuntime) { return cleanExit(false, "Failed to open file for writing"); }
+
+        if (serializeJson(doc, fRuntime) == 0) {
+            fRuntime.close();
+            return cleanExit(false, "Failed to serialize to file");
+        }
+
         fRuntime.close();
-        return cleanExit(false, "Failed to serialize to file");
-    }
 
-    fRuntime.close();
-
-    { // commit the new state only after a successful write
-        std::lock_guard<std::mutex> lock(_mutex);
+        // commit the new state only after a successful write
         _writeVersion = RUNTIME_VERSION;
         _writeEpoch = nextEpoch;
         _writeCount = nextCount;
+
     } // mutex is automatically released when lock goes out of this scope
 
     return cleanExit(true, "Written to file");
@@ -210,17 +217,20 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
  * Returns true at the daily trigger time at 00:05
  */
 bool RuntimeClass::getWriteTrigger(void) {
+
+    struct tm nowTime;
+    if (!getLocalTime(&nowTime, 5)) {
+        return false;
+    }
+
     std::lock_guard<std::mutex> lock(_mutex);
-    struct tm actTime;
-    if (getLocalTime(&actTime, 5)) {
-        if ((actTime.tm_hour == 0) && (actTime.tm_min >= 5) && (actTime.tm_min <= 10)) {
-            if (_lastTrigger == false) {
-                _lastTrigger = true;
-                return true;
-            }
-        } else {
-            _lastTrigger = false;
+    if ((nowTime.tm_hour == 0) && (nowTime.tm_min >= 5) && (nowTime.tm_min <= 10)) {
+        if (_lastTrigger == false) {
+            _lastTrigger = true;
+            return true;
         }
+    } else {
+        _lastTrigger = false;
     }
     return false;
 }

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/* Runtime Data Management
+ *
+ * Read and write runtime data persistent on LittleFS
+ * - The data is stored in JSON format.
+ * - The data is written once a day at 00:05, during WebApp 'OTA firmware update' and 'Reset'.
+ * - The data is not written if last write was less then 1 hour ago.
+ * - Threadsave access to the data is provided by a mutex.
+ * Note: Additional runtime data must be added in the read() and write() methods.
+ *       To avoid reenter deadlocks, do not call write() or read() from a locally locked mutex to save local data!
+ *
+ * 2025.09.11 - 1.0 - first version
+ */
+
+#include <Utils.h>
+#include <LittleFS.h>
+#include <LogHelper.h>
+#include "RuntimeData.h"
+
+
+#undef TAG
+static const char* TAG = "configuration";
+static const char* SUBTAG = "runtime";
+
+
+constexpr const char* RUNTIME_FILENAME = "/runtime.json";   // filename of the runtime data file
+constexpr uint16_t RUNTIME_VERSION = 0;                     // version of the runtime data structure, prepared for future use
+
+
+RuntimeClass RuntimeData {RUNTIME_VERSION}; // singleton instance
+
+
+/*
+ * Init the runtime data loop task
+ */
+void RuntimeClass::init(Scheduler& scheduler)
+{
+    scheduler.addTask(_loopTask);
+    _loopTask.setCallback(std::bind(&RuntimeClass::loop, this));
+    _loopTask.setIterations(TASK_FOREVER);
+    _loopTask.setInterval(60 * 1000); // every minute
+    _loopTask.enable();
+}
+
+
+/*
+ * The runtime data loop is called every minute
+ */
+void RuntimeClass::loop(void)
+{
+    // check whether it is time to write the runtime data
+    if (getWriteTrigger()) { write(); }
+}
+
+
+/*
+ * Writes the runtime data to LittleFS file
+ */
+bool RuntimeClass::write(void)
+{
+    auto cleanExit = [this](const bool writeOk, const char* text) -> bool {
+        if (writeOk) {
+            DTU_LOGI("%s", text);
+        } else {
+            DTU_LOGE("%s", text);
+        }
+        _writeOK = writeOk;
+        return writeOk;
+    };
+
+    // we need the local time before we can write the runtime data
+    time_t nowEpoch;
+    if (!Utils::getEpoch(&nowEpoch, 5)) { return cleanExit(true, "Local time not available, skipping write"); }
+
+    JsonDocument doc;
+    { // mutex is automatically released when lock goes out of this scope
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        // we do not write more than once in a hour
+        if ((_writeEpoch != 0) && (difftime(nowEpoch, _writeEpoch) < 60 * 60)) {
+            return cleanExit(true, "Last write less than 1 hour ago, skipping write");
+        }
+
+        _writeEpoch = nowEpoch;
+        _writeCount++;
+        JsonObject info = doc["info"].to<JsonObject>();
+        info["version"] = _writeVersion;
+        info["save_count"] = _writeCount;
+        info["save_epoch"] = _writeEpoch;
+    } // mutex is automatically released when lock goes out of this scope
+
+    // Insert additional runtime data here and protect the shared data with a local mutex
+
+
+    if (!Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
+        return cleanExit(false, "JSON alloc fault, skipping write");
+    }
+
+    File fRuntime = LittleFS.open(RUNTIME_FILENAME, "w");
+    if (!fRuntime) { return cleanExit(false, "Failed to open file for writing"); }
+
+    if (serializeJson(doc, fRuntime) == 0) {
+        fRuntime.close();
+        return cleanExit(false, "Failed to serialize to file");
+    }
+
+    fRuntime.close();
+    return cleanExit(true, "Written to file");
+}
+
+
+/*
+ * Read the runtime data from LittleFS file
+ */
+bool RuntimeClass::read(void)
+{
+    bool readOk = false;
+    JsonDocument doc;
+
+    // Note: We do not exit on read or allocation errors. In that case we need the default values
+    File fRuntime = LittleFS.open(RUNTIME_FILENAME, "r", false);
+    if (fRuntime) {
+        Utils::skipBom(fRuntime);
+        DeserializationError error = deserializeJson(doc, fRuntime);
+        if (!error && Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
+            readOk = true; // success of reading the runtime data
+        }
+    }
+
+    JsonObject info = doc["info"];
+    { // mutex is automatically released when lock goes out of this scope
+        std::lock_guard<std::mutex> lock(_mutex);
+        _writeVersion = info["version"] | RUNTIME_VERSION;
+        _writeCount = info["save_count"] | 0U;
+        _writeEpoch = info["save_epoch"] | 0U;
+    } // mutex is automatically released when lock goes out of this scope
+
+    // deserialize additional runtime data here, prepare default values and protect the shared data with a local mutex
+
+
+    if (fRuntime) { fRuntime.close(); }
+    if (readOk) {
+        DTU_LOGI("Read successfully");
+    } else {
+        DTU_LOGE("Read fault, using default values");
+    }
+    _readOK = readOk;
+    return readOk;
+}
+
+
+/*
+ * Get the write counter
+ */
+uint16_t RuntimeClass::getWriteCount(void) const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _writeCount;
+}
+
+
+/*
+ * Get the write epoch time
+ */
+time_t RuntimeClass::getWriteEpochTime(void) const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _writeEpoch;
+}
+
+
+/*
+ * Get the write count and time as string
+ * Format: "<count> / <dd>-<mon> <hh>:<mm>"
+ * If epoch time and local time is not available the time is replaced by "no time"
+ */
+String RuntimeClass::getWriteCountAndTimeString(void) const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    char buf[32] = "";
+    struct tm time;
+    if ((_writeEpoch != 0) && (getLocalTime(&time, 5))) {
+        localtime_r(&_writeEpoch, &time);
+        strftime(buf, sizeof(buf), " / %d-%h %R", &time);
+    } else {
+        snprintf(buf, sizeof(buf), " / no time");
+    }
+    String ctString = String(_writeCount) + String(buf);
+    return ctString;
+}
+
+
+/*
+ * Returns true at the daily trigger time at 00:05
+ */
+bool RuntimeClass::getWriteTrigger(void) const {
+    static bool lastTrigger = false;
+    struct tm actTime;
+    if (getLocalTime(&actTime, 5)) {
+        if ((actTime.tm_hour == 0) && (actTime.tm_min >= 5) && (actTime.tm_min <= 10)) {
+            if (lastTrigger == false) {
+                lastTrigger = true;
+                return true;
+            }
+        } else {
+            lastTrigger = false;
+        }
+    }
+    return false;
+}

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -3,12 +3,14 @@
 /* Runtime Data Management
  *
  * Read and write runtime data persistent on LittleFS
- * - The data is stored in JSON format.
- * - The data is written once a day at 00:05, during WebApp 'OTA firmware update' and 'Reset'.
- * - The data is not written if last write was less then 1 hour ago.
+ * - The data is stored in JSON format
+ * - The data is written during WebApp 'OTA firmware upgrade' and during Webapp 'Reboot'
+ * - For security reasons such as 'unexpected power cycles' or 'physical resets', data is also written once a day at 00:05
+ * - The data will not be written if the last write operation was less than one hour ago.
  * - Threadsave access to the data is provided by a mutex.
- * Note: Additional runtime data must be added in the read() and write() methods.
- *       To avoid reenter deadlocks, do not call write() or read() from a locally locked mutex to save local data!
+ *
+ * Note: Runtime data must be added in the read() and write() methods.
+ *       To avoid reenter deadlocks, do not call write() or read() from a locally locked mutex to save local data on demand!
  *
  * 2025.09.11 - 1.0 - first version
  */
@@ -20,8 +22,8 @@
 
 
 #undef TAG
-static const char* TAG = "configuration";
-static const char* SUBTAG = "runtime";
+static const char* TAG = "runtimedata";
+static const char* SUBTAG = "Handler";
 
 
 constexpr const char* RUNTIME_FILENAME = "/runtime.json";   // filename of the runtime data file
@@ -49,15 +51,16 @@ void RuntimeClass::init(Scheduler& scheduler)
  */
 void RuntimeClass::loop(void)
 {
-    // check whether it is time to write the runtime data
-    if (getWriteTrigger()) { write(); }
+    // check whether it is time to write the runtime data but do not write if last write operation was less than 60 min ago
+    if (getWriteTrigger()) { write(60); }
 }
 
 
 /*
  * Writes the runtime data to LittleFS file
+ * freezeTime: Minimum necessary time [minutes] between now and last write operation
  */
-bool RuntimeClass::write(void)
+bool RuntimeClass::write(uint16_t const freezeTime = 10)
 {
     auto cleanExit = [this](const bool writeOk, const char* text) -> bool {
         if (writeOk) {
@@ -78,7 +81,7 @@ bool RuntimeClass::write(void)
         std::lock_guard<std::mutex> lock(_mutex);
 
         // we do not write more than once in a hour
-        if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * 60)) {
+        if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeTime)) {
             return cleanExit(true, "Last write less than 1 hour ago, skipping write");
         }
         nextCount = _writeCount + 1;
@@ -189,6 +192,8 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
     std::lock_guard<std::mutex> lock(_mutex);
     char buf[32] = "";
     struct tm time;
+
+    // Check if time service is available before converting epoch to local time
     if ((_writeEpoch != 0) && (getLocalTime(&time, 5))) {
         localtime_r(&_writeEpoch, &time);
         strftime(buf, sizeof(buf), " / %d-%h %R", &time);

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -69,28 +69,29 @@ bool RuntimeClass::write(void)
         return writeOk;
     };
 
-    // we need the local time before we can write the runtime data
-    time_t nowEpoch;
-    if (!Utils::getEpoch(&nowEpoch, 5)) { return cleanExit(true, "Local time not available, skipping write"); }
+    // we need the next local time before we can write the runtime data
+    time_t nextEpoch;
+    if (!Utils::getEpoch(&nextEpoch, 5)) { return cleanExit(true, "Local time not available, skipping write"); }
+    uint16_t nextCount;
 
-    JsonDocument doc;
-    { // mutex is automatically released when lock goes out of this scope
+    { // prepare the next write count
         std::lock_guard<std::mutex> lock(_mutex);
 
         // we do not write more than once in a hour
-        if ((_writeEpoch != 0) && (difftime(nowEpoch, _writeEpoch) < 60 * 60)) {
+        if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * 60)) {
             return cleanExit(true, "Last write less than 1 hour ago, skipping write");
         }
-
-        _writeEpoch = nowEpoch;
-        _writeCount++;
-        JsonObject info = doc["info"].to<JsonObject>();
-        info["version"] = _writeVersion;
-        info["save_count"] = _writeCount;
-        info["save_epoch"] = _writeEpoch;
+        nextCount = _writeCount + 1;
     } // mutex is automatically released when lock goes out of this scope
 
+    JsonDocument doc;
+    JsonObject info = doc["info"].to<JsonObject>();
+    info["version"] = RUNTIME_VERSION;
+    info["save_count"] = nextCount;
+    info["save_epoch"] = nextEpoch;
+
     // Insert additional runtime data here and protect the shared data with a local mutex
+
 
 
     if (!Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
@@ -106,6 +107,14 @@ bool RuntimeClass::write(void)
     }
 
     fRuntime.close();
+
+    { // commit the new state only after a successful write
+        std::lock_guard<std::mutex> lock(_mutex);
+        _writeVersion = RUNTIME_VERSION;
+        _writeEpoch = nextEpoch;
+        _writeCount = nextCount;
+    } // mutex is automatically released when lock goes out of this scope
+
     return cleanExit(true, "Written to file");
 }
 

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -20,6 +20,7 @@
 #include <Utils.h>
 #include <LittleFS.h>
 #include <LogHelper.h>
+#include <battery/Controller.h>
 #include "RuntimeData.h"
 
 
@@ -101,7 +102,7 @@ bool RuntimeClass::write(uint16_t const freezeMinutes)
         info["save_epoch"] = nextEpoch;
 
         // Insert additional runtime data here and protect the shared data with a local mutex
-
+        Battery.serializeRTD(doc["battery"].to<JsonObject>());
 
 
         if (!Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
@@ -156,7 +157,7 @@ bool RuntimeClass::read(void)
     } // mutex is automatically released when lock goes out of this scope
 
     // deserialize additional runtime data here, prepare default values and protect the shared data with a local mutex
-
+    Battery.deserializeRTD(doc["battery"]);
 
     if (fRuntime) { fRuntime.close(); }
     if (readOk) {

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -194,17 +194,16 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
 /*
  * Returns true at the daily trigger time at 00:05
  */
-bool RuntimeClass::getWriteTrigger(void) const {
-    static bool lastTrigger = false;
+bool RuntimeClass::getWriteTrigger(void) {
     struct tm actTime;
     if (getLocalTime(&actTime, 5)) {
         if ((actTime.tm_hour == 0) && (actTime.tm_min >= 5) && (actTime.tm_min <= 10)) {
-            if (lastTrigger == false) {
-                lastTrigger = true;
+            if (_lastTrigger == false) {
+                _lastTrigger = true;
                 return true;
             }
         } else {
-            lastTrigger = false;
+            _lastTrigger = false;
         }
     }
     return false;

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -60,7 +60,7 @@ void RuntimeClass::loop(void)
  * Writes the runtime data to LittleFS file
  * freezeTime: Minimum necessary time [minutes] between now and last write operation
  */
-bool RuntimeClass::write(uint16_t const freezeTime = 10)
+bool RuntimeClass::write(uint16_t const freezeTime)
 {
     auto cleanExit = [this](const bool writeOk, const char* text) -> bool {
         if (writeOk) {
@@ -74,7 +74,7 @@ bool RuntimeClass::write(uint16_t const freezeTime = 10)
 
     // we need the next local time before we can write the runtime data
     time_t nextEpoch;
-    if (!Utils::getEpoch(&nextEpoch, 5)) { return cleanExit(true, "Local time not available, skipping write"); }
+    if (!Utils::getEpoch(&nextEpoch, 5)) { return cleanExit(false, "Local time not available, skipping write"); }
     uint16_t nextCount;
 
     { // prepare the next write count
@@ -82,7 +82,7 @@ bool RuntimeClass::write(uint16_t const freezeTime = 10)
 
         // we do not write more than once in a hour
         if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeTime)) {
-            return cleanExit(true, "Last write less than 1 hour ago, skipping write");
+            return cleanExit(false, "Time interval between 2 write operations too short, skipping write");
         }
         nextCount = _writeCount + 1;
     } // mutex is automatically released when lock goes out of this scope
@@ -207,6 +207,7 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
 
 /*
  * Returns true at the daily trigger time at 00:05
+ * Note: This function is not protected by a mutex, but if it is only called by loop() and loop() is only executed on a single thread, we are safe
  */
 bool RuntimeClass::getWriteTrigger(void) {
     struct tm actTime;

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -87,7 +87,7 @@ bool RuntimeClass::write(uint16_t const freezeMinutes)
         std::lock_guard<std::mutex> lock(_mutex);
 
         // check minimum interval between writes (enforced only when freezeMinutes > 0)
-        if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeMinutes)) {
+        if ((freezeMinutes > 0) && (_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeMinutes)) {
             return cleanExit(false, "Time interval between 2 write operations too short, skipping write");
         }
 
@@ -214,7 +214,7 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
 
 
 /*
- * Returns true at the daily trigger time at 00:05
+ * Returns true once a day between 00:05 - 00:10
  */
 bool RuntimeClass::getWriteTrigger(void) {
 

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -58,9 +58,9 @@ void RuntimeClass::loop(void)
 
 /*
  * Writes the runtime data to LittleFS file
- * freezeTime: Minimum necessary time [minutes] between now and last write operation
+ * freezeMinutes: Minimum necessary time [minutes] between now and last write operation
  */
-bool RuntimeClass::write(uint16_t const freezeTime)
+bool RuntimeClass::write(uint16_t const freezeMinutes)
 {
     auto cleanExit = [this](const bool writeOk, const char* text) -> bool {
         if (writeOk) {
@@ -81,7 +81,7 @@ bool RuntimeClass::write(uint16_t const freezeTime)
         std::lock_guard<std::mutex> lock(_mutex);
 
         // we do not write more than once in a hour
-        if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeTime)) {
+        if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeMinutes)) {
             return cleanExit(false, "Time interval between 2 write operations too short, skipping write");
         }
         nextCount = _writeCount + 1;
@@ -193,7 +193,8 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
     char buf[32] = "";
     struct tm time;
 
-    // Check if time service is available before converting epoch to local time
+    // Before we can convert the epoch to local time, we need to ensure we've received the correct time
+    // from the time server. This may take some time after the system boots.
     if ((_writeEpoch != 0) && (getLocalTime(&time, 5))) {
         localtime_r(&_writeEpoch, &time);
         strftime(buf, sizeof(buf), " / %d-%h %R", &time);
@@ -207,9 +208,9 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
 
 /*
  * Returns true at the daily trigger time at 00:05
- * Note: This function is not protected by a mutex, but if it is only called by loop() and loop() is only executed on a single thread, we are safe
  */
 bool RuntimeClass::getWriteTrigger(void) {
+    std::lock_guard<std::mutex> lock(_mutex);
     struct tm actTime;
     if (getLocalTime(&actTime, 5)) {
         if ((actTime.tm_hour == 0) && (actTime.tm_min >= 5) && (actTime.tm_min <= 10)) {

--- a/src/WebApi_firmware.cpp
+++ b/src/WebApi_firmware.cpp
@@ -48,6 +48,9 @@ void WebApiFirmwareClass::onFirmwareUpdateFinish(AsyncWebServerRequest* request)
     response->addHeader(asyncsrv::T_Connection, asyncsrv::T_close);
     response->addHeader(asyncsrv::T_CORS_ACAO, "*");
     request->send(response);
+
+    // write the runtime data to LittleFS, but do not write if last write operation was less than 60 min ago
+    RuntimeData.write(60);
     RestartHelper.triggerRestart();
 }
 
@@ -85,7 +88,6 @@ void WebApiFirmwareClass::onFirmwareUpdateUpload(AsyncWebServerRequest* request,
     }
 
     if (final) { // if the final flag is set then this is the last frame of data
-        RuntimeData.write(); // write the runtime data to LittleFS
         if (!Update.end(true)) { // true to set the size to the current progress
             Update.printError(Serial);
             return request->send(400, asyncsrv::T_text_plain, "Could not end OTA");

--- a/src/WebApi_firmware.cpp
+++ b/src/WebApi_firmware.cpp
@@ -10,6 +10,7 @@
 #include <AsyncJson.h>
 #include <Update.h>
 #include "esp_partition.h"
+#include "RuntimeData.h"
 
 void WebApiFirmwareClass::init(AsyncWebServer& server, Scheduler& scheduler)
 {
@@ -84,6 +85,7 @@ void WebApiFirmwareClass::onFirmwareUpdateUpload(AsyncWebServerRequest* request,
     }
 
     if (final) { // if the final flag is set then this is the last frame of data
+        RuntimeData.write(); // write the runtime data to LittleFS
         if (!Update.end(true)) { // true to set the size to the current progress
             Update.printError(Serial);
             return request->send(400, asyncsrv::T_text_plain, "Could not end OTA");

--- a/src/WebApi_maintenance.cpp
+++ b/src/WebApi_maintenance.cpp
@@ -8,6 +8,7 @@
 #include "WebApi.h"
 #include "WebApi_errors.h"
 #include <AsyncJson.h>
+#include "RuntimeData.h"
 
 void WebApiMaintenanceClass::init(AsyncWebServer& server, Scheduler& scheduler)
 {
@@ -43,6 +44,7 @@ void WebApiMaintenanceClass::onRebootPost(AsyncWebServerRequest* request)
         retMsg["code"] = WebApiError::MaintenanceRebootTriggered;
 
         WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
+        RuntimeData.write(); // write the runtime data to LittleFS
         RestartHelper.triggerRestart();
     } else {
         retMsg["message"] = "Reboot cancled!";

--- a/src/WebApi_maintenance.cpp
+++ b/src/WebApi_maintenance.cpp
@@ -44,7 +44,9 @@ void WebApiMaintenanceClass::onRebootPost(AsyncWebServerRequest* request)
         retMsg["code"] = WebApiError::MaintenanceRebootTriggered;
 
         WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
-        RuntimeData.write(); // write the runtime data to LittleFS
+
+        // write the runtime data to LittleFS, but do not write if last write operation was less than 60 min ago
+        RuntimeData.write(60);
         RestartHelper.triggerRestart();
     } else {
         retMsg["message"] = "Reboot cancled!";

--- a/src/WebApi_sysstatus.cpp
+++ b/src/WebApi_sysstatus.cpp
@@ -14,6 +14,7 @@
 #include <Hoymiles.h>
 #include <LittleFS.h>
 #include <ResetReason.h>
+#include "RuntimeData.h"
 
 void WebApiSysstatusClass::init(AsyncWebServer& server, Scheduler& scheduler)
 {
@@ -79,6 +80,7 @@ void WebApiSysstatusClass::onSystemStatus(AsyncWebServerRequest* request)
     root["resetreason_1"] = reason;
 
     root["cfgsavecount"] = Configuration.get().Cfg.SaveCount;
+    root["runtime_savecount"] = RuntimeData.getWriteCountAndTimeString();
 
     char version[16];
     snprintf(version, sizeof(version), "%d.%d.%d", CONFIG_VERSION >> 24 & 0xff, CONFIG_VERSION >> 16 & 0xff, CONFIG_VERSION >> 8 & 0xff);

--- a/src/battery/Controller.cpp
+++ b/src/battery/Controller.cpp
@@ -95,7 +95,7 @@ void Controller::loop()
 
     _upProvider->loop();
 
-    _upProvider->getStats()->checkFullyChargedTime();
+    _upProvider->getStats()->checkSoCFullEpoch();
 
     _upProvider->getStats()->mqttLoop();
 
@@ -164,7 +164,7 @@ void Controller::serializeRTD(JsonObject const& obj) const
         return;
     }
 
-    obj["fully_charged_epoch"] = _upProvider->getStats()->getFullyChargedTime().value_or(0);
+    obj["fully_charged_epoch"] = _upProvider->getStats()->getSoCFullEpoch().value_or(0);
 }
 
 void Controller::deserializeRTD(JsonObject const& obj)
@@ -173,8 +173,8 @@ void Controller::deserializeRTD(JsonObject const& obj)
 
     if (!_upProvider) { return; } // no battery, nothing to do
 
-    time_t fulltime =  obj["fully_charged_epoch"] | 0;
-    _upProvider->getStatsForWrite()->setFullyChargedTime(fulltime == 0 ? std::nullopt : std::make_optional(fulltime));
+    time_t fullEpoch =  obj["fully_charged_epoch"] | 0;
+    _upProvider->setFullyChargedEpoch(fullEpoch == 0 ? std::nullopt : std::make_optional(fullEpoch));
 }
 
 } // namespace Batteries

--- a/src/battery/Controller.cpp
+++ b/src/battery/Controller.cpp
@@ -10,6 +10,7 @@
 #include <battery/zendure/Provider.h>
 #include <Configuration.h>
 #include <LogHelper.h>
+#include <Utils.h>
 
 #undef TAG
 static const char* TAG = "battery";
@@ -94,6 +95,8 @@ void Controller::loop()
 
     _upProvider->loop();
 
+    _upProvider->getStats()->checkFullyChargedTime();
+
     _upProvider->getStats()->mqttLoop();
 
     auto spHassIntegration = _upProvider->getHassIntegration();
@@ -150,6 +153,28 @@ float Controller::getDischargeCurrentLimit()
     };
 
     return std::min(getConfiguredLimit(), getBatteryLimit());
+}
+
+void Controller::serializeRTD(JsonObject const& obj) const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    if (!_upProvider) {
+        obj["fully_charged_epoch"] = 0; // no battery in the system
+        return;
+    }
+
+    obj["fully_charged_epoch"] = _upProvider->getStats()->getFullyChargedTime().value_or(0);
+}
+
+void Controller::deserializeRTD(JsonObject const& obj)
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    if (!_upProvider) { return; } // no battery, nothing to do
+
+    time_t fulltime =  obj["fully_charged_epoch"] | 0;
+    _upProvider->setStats()->setFullyChargedTime(fulltime == 0 ? std::nullopt : std::make_optional(fulltime));
 }
 
 } // namespace Batteries

--- a/src/battery/Controller.cpp
+++ b/src/battery/Controller.cpp
@@ -174,7 +174,7 @@ void Controller::deserializeRTD(JsonObject const& obj)
     if (!_upProvider) { return; } // no battery, nothing to do
 
     time_t fulltime =  obj["fully_charged_epoch"] | 0;
-    _upProvider->setStats()->setFullyChargedTime(fulltime == 0 ? std::nullopt : std::make_optional(fulltime));
+    _upProvider->getStatsForWrite()->setFullyChargedTime(fulltime == 0 ? std::nullopt : std::make_optional(fulltime));
 }
 
 } // namespace Batteries

--- a/src/battery/Stats.cpp
+++ b/src/battery/Stats.cpp
@@ -144,11 +144,12 @@ void Stats::checkSoCFullEpoch(void)
     lastUpdate = _lastUpdate;
     time_t nowEpoch;
 
-    // The goal is to record the time when we reach 100% SoC, to record the time as long as we have 100% SoC,
-    // and to maintain the time until we reach 100% SoC again.
+    // The goal is to capture the moment we reach 100% SoC, to continuously capture the time while we have 100% SoC,
+    // and to record the last time until we reach 100% SoC again.
     if (isSoCValid() && (getSoCAgeSeconds() <= 30) && (getSoC() >= 100.0f) && Utils::getEpoch(&nowEpoch, 5)) {
-        if (!_oSoCFullEpoch.has_value() || (nowEpoch > _oSoCFullEpoch.value())) {
-            _oSoCFullEpoch = nowEpoch;
+        auto lastSoCEpoch = getSoCFullEpoch();
+        if (!lastSoCEpoch.has_value() || (nowEpoch > lastSoCEpoch.value())) {
+            setSoCFullEpoch(nowEpoch);
         }
     }
 }

--- a/src/battery/Stats.cpp
+++ b/src/battery/Stats.cpp
@@ -54,9 +54,13 @@ void Stats::getLiveViewData(JsonVariant& root) const
         time_t nowTime;
         localtime_r(&_oSoCFullTime.value(), &fullTime);
         fullTime.tm_hour = fullTime.tm_min = fullTime.tm_sec = 0; // always start from midnight
-        Utils::getEpoch(&nowTime, 5);
-        auto days = static_cast<uint16_t>(difftime(nowTime, mktime(&fullTime)) / (60.0 * 60.0 * 24.0));
-        addLiveViewValue(root, "fullyChargedDays", days, "days", 0);
+        if (Utils::getEpoch(&nowTime, 5)) {
+            auto midnightEpoch = mktime(&fullTime);
+            if ((midnightEpoch != -1) && (nowTime >= midnightEpoch)) {
+                auto days = static_cast<uint16_t>(difftime(nowTime, midnightEpoch) / (60.0 * 60.0 * 24.0));
+                addLiveViewValue(root, "fullyChargedDays", days, "days", 0);
+            }
+        }
     }
 
     if (isVoltageValid()) {

--- a/src/battery/Stats.cpp
+++ b/src/battery/Stats.cpp
@@ -49,6 +49,16 @@ void Stats::getLiveViewData(JsonVariant& root) const
         addLiveViewValue(root, "SoC", _soc, "%", _socPrecision);
     }
 
+    if (_oSoCFullTime.has_value()) {
+        tm fullTime;
+        time_t nowTime;
+        localtime_r(&_oSoCFullTime.value(), &fullTime);
+        fullTime.tm_hour = fullTime.tm_min = fullTime.tm_sec = 0; // always start from midnight
+        Utils::getEpoch(&nowTime, 5);
+        auto days = static_cast<uint16_t>(difftime(nowTime, mktime(&fullTime)) / (60.0 * 60.0 * 24.0));
+        addLiveViewValue(root, "fullyChargedDays", days, "days", 0);
+    }
+
     if (isVoltageValid()) {
         addLiveViewValue(root, "voltage", _voltage, "V", 2);
     }

--- a/src/battery/Stats.cpp
+++ b/src/battery/Stats.cpp
@@ -49,10 +49,10 @@ void Stats::getLiveViewData(JsonVariant& root) const
         addLiveViewValue(root, "SoC", _soc, "%", _socPrecision);
     }
 
-    if (_oSoCFullTime.has_value()) {
+    if (_oSoCFullEpoch.has_value()) {
         tm fullTime;
         time_t nowTime;
-        localtime_r(&_oSoCFullTime.value(), &fullTime);
+        localtime_r(&_oSoCFullEpoch.value(), &fullTime);
         fullTime.tm_hour = fullTime.tm_min = fullTime.tm_sec = 0; // always start from midnight
         if (Utils::getEpoch(&nowTime, 5)) {
             auto midnightEpoch = mktime(&fullTime);
@@ -136,11 +136,19 @@ void Stats::mqttPublish() const
     }
 }
 
-void Stats::checkFullyChargedTime(void)
+void Stats::checkSoCFullEpoch(void)
 {
-    time_t fulltime;
-    if (isSoCValid() && (getSoCAgeSeconds() <= 30) && (getSoC() >= 100.0f) && Utils::getEpoch(&fulltime, 5)) {
-        _oSoCFullTime = fulltime;
+    static uint32_t lastUpdate = 0;
+
+    if (lastUpdate == _lastUpdate) { return; } // fast exit from already processed values
+    lastUpdate = _lastUpdate;
+    time_t nowEpoch;
+
+    // The goal is to save the last epoch time the battery was at 100% SoC and maintain that value until we reach 100% again.
+    if (isSoCValid() && (getSoCAgeSeconds() <= 30) && (getSoC() >= 100.0f) && Utils::getEpoch(&nowEpoch, 5)) {
+        if (!_oSoCFullEpoch.has_value() || (nowEpoch > _oSoCFullEpoch.value())) {
+            _oSoCFullEpoch = nowEpoch;
+        }
     }
 }
 

--- a/src/battery/Stats.cpp
+++ b/src/battery/Stats.cpp
@@ -144,7 +144,8 @@ void Stats::checkSoCFullEpoch(void)
     lastUpdate = _lastUpdate;
     time_t nowEpoch;
 
-    // The goal is to save the last epoch time the battery was at 100% SoC and maintain that value until we reach 100% again.
+    // The goal is to record the time when we reach 100% SoC, to record the time as long as we have 100% SoC,
+    // and to maintain the time until we reach 100% SoC again.
     if (isSoCValid() && (getSoCAgeSeconds() <= 30) && (getSoC() >= 100.0f) && Utils::getEpoch(&nowEpoch, 5)) {
         if (!_oSoCFullEpoch.has_value() || (nowEpoch > _oSoCFullEpoch.value())) {
             _oSoCFullEpoch = nowEpoch;

--- a/src/battery/Stats.cpp
+++ b/src/battery/Stats.cpp
@@ -3,6 +3,7 @@
 #include <battery/Stats.h>
 #include <Configuration.h>
 #include <MqttSettings.h>
+#include "Utils.h"
 
 namespace Batteries {
 
@@ -118,6 +119,14 @@ void Stats::mqttPublish() const
 
     if (isChargeCurrentLimitValid()) {
         MqttSettings.publish("battery/settings/chargeCurrentLimitation", String(_chargeCurrentLimit));
+    }
+}
+
+void Stats::checkFullyChargedTime(void)
+{
+    time_t fulltime;
+    if (isSoCValid() && (getSoCAgeSeconds() <= 30) && (getSoC() >= 100.0f) && Utils::getEpoch(&fulltime, 5)) {
+        _oSoCFullTime = fulltime;
     }
 }
 

--- a/src/battery/victronsmartshunt/Stats.cpp
+++ b/src/battery/victronsmartshunt/Stats.cpp
@@ -75,14 +75,17 @@ void Stats::checkSoCFullEpoch(void) {
     lastUpdate = _lastUpdate;
     time_t nowEpoch;
 
-    if (Utils::getEpoch(&nowEpoch, 5)) {
+    if (isSoCValid() && (getSoCAgeSeconds() <= 30) && Utils::getEpoch(&nowEpoch, 5)) {
+
+        // invalid value from shunt, we do not process
+        if ((_lastFullCharge < 0) || (_lastFullCharge > (365 * 24 * 60))) { return; }
 
         // reverse calculation to get 'fully charged epoch' from the smart shunt duration value
         auto shuntEpoch = std::make_optional(nowEpoch - static_cast<time_t>(_lastFullCharge * 60));
         auto lastEpoch = getSoCFullEpoch();
 
         // We only update if the value is not in the future and we don't have epoch yet or we have a newer value
-        if ((shuntEpoch.value() <= nowEpoch) && (!lastEpoch.has_value() || (shuntEpoch.value() > lastEpoch))) {
+        if ((shuntEpoch.value() <= nowEpoch) && (!lastEpoch.has_value() || (shuntEpoch.value() > lastEpoch.value()))) {
             setSoCFullEpoch(shuntEpoch);
         }
     }

--- a/src/battery/victronsmartshunt/Stats.cpp
+++ b/src/battery/victronsmartshunt/Stats.cpp
@@ -75,7 +75,7 @@ void Stats::checkSoCFullEpoch(void) {
     lastUpdate = _lastUpdate;
     time_t nowEpoch;
 
-    if (isSoCValid() && (getSoCAgeSeconds() <= 30) && (_lastFullCharge > 0) && Utils::getEpoch(&nowEpoch, 5)) {
+    if (Utils::getEpoch(&nowEpoch, 5)) {
 
         // reverse calculation to get 'fully charged epoch' from the smart shunt duration value
         auto shuntEpoch = std::make_optional(nowEpoch - static_cast<time_t>(_lastFullCharge * 60));

--- a/src/battery/victronsmartshunt/Stats.cpp
+++ b/src/battery/victronsmartshunt/Stats.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include <MqttSettings.h>
 #include <battery/victronsmartshunt/Stats.h>
+#include <Utils.h>
 
 namespace Batteries::VictronSmartShunt {
 
@@ -65,6 +66,19 @@ void Stats::mqttPublish() const {
     MqttSettings.publish("battery/lastFullCharge", String(_lastFullCharge));
     MqttSettings.publish("battery/midpointVoltage", String(_midpointVoltage));
     MqttSettings.publish("battery/midpointDeviation", String(_midpointDeviation));
+}
+
+void Stats::checkFullyChargedTime(void) {
+    time_t aktTime;
+    if (isSoCValid() && (getSoCAgeSeconds() <= 30) && (_lastFullCharge > 0) && Utils::getEpoch(&aktTime, 5)) {
+        auto lastTime = getFullyChargedTime();
+        auto shuntTime = difftime(aktTime, _lastFullCharge * 60.0);
+
+        // We only update if we don't have time yet or if the new time is later
+        if (!lastTime.has_value() || (difftime(shuntTime, lastTime.value()) > 0.0)) {
+            setFullyChargedTime(shuntTime);
+        }
+    }
 }
 
 } // namespace Batteries::VictronSmartShunt

--- a/src/battery/victronsmartshunt/Stats.cpp
+++ b/src/battery/victronsmartshunt/Stats.cpp
@@ -69,10 +69,10 @@ void Stats::mqttPublish() const {
 }
 
 void Stats::checkFullyChargedTime(void) {
-    time_t aktTime;
-    if (isSoCValid() && (getSoCAgeSeconds() <= 30) && (_lastFullCharge > 0) && Utils::getEpoch(&aktTime, 5)) {
+    time_t nowTime;
+    if (isSoCValid() && (getSoCAgeSeconds() <= 30) && (_lastFullCharge > 0) && Utils::getEpoch(&nowTime, 5)) {
         auto lastTime = getFullyChargedTime();
-        auto shuntTime = difftime(aktTime, _lastFullCharge * 60.0);
+        auto shuntTime = difftime(nowTime, _lastFullCharge * 60.0);
 
         // We only update if we don't have time yet or if the new time is later
         if (!lastTime.has_value() || (difftime(shuntTime, lastTime.value()) > 0.0)) {

--- a/src/battery/victronsmartshunt/Stats.cpp
+++ b/src/battery/victronsmartshunt/Stats.cpp
@@ -68,15 +68,22 @@ void Stats::mqttPublish() const {
     MqttSettings.publish("battery/midpointDeviation", String(_midpointDeviation));
 }
 
-void Stats::checkFullyChargedTime(void) {
-    time_t nowTime;
-    if (isSoCValid() && (getSoCAgeSeconds() <= 30) && (_lastFullCharge > 0) && Utils::getEpoch(&nowTime, 5)) {
-        auto lastTime = getFullyChargedTime();
-        auto shuntTime = difftime(nowTime, _lastFullCharge * 60.0);
+void Stats::checkSoCFullEpoch(void) {
+    static uint32_t lastUpdate = 0;
 
-        // We only update if we don't have time yet or if the new time is later
-        if (!lastTime.has_value() || (difftime(shuntTime, lastTime.value()) > 0.0)) {
-            setFullyChargedTime(shuntTime);
+    if (lastUpdate == _lastUpdate) { return; } // fast exit from already processed values
+    lastUpdate = _lastUpdate;
+    time_t nowEpoch;
+
+    if (isSoCValid() && (getSoCAgeSeconds() <= 30) && (_lastFullCharge > 0) && Utils::getEpoch(&nowEpoch, 5)) {
+
+        // reverse calculation to get 'fully charged epoch' from the smart shunt duration value
+        auto shuntEpoch = std::make_optional(nowEpoch - static_cast<time_t>(_lastFullCharge * 60));
+        auto lastEpoch = getSoCFullEpoch();
+
+        // We only update if the value is not in the future and we don't have epoch yet or we have a newer value
+        if ((shuntEpoch.value() <= nowEpoch) && (!lastEpoch.has_value() || (shuntEpoch.value() > lastEpoch))) {
+            setSoCFullEpoch(shuntEpoch);
         }
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,14 +146,17 @@ void setup()
     Datastore.init(scheduler);
     RestartHelper.init(scheduler);
 
-    // OpenDTU-OnBattery-specific initializations go below
-    RuntimeData.init(scheduler);
-    RuntimeData.read(); // make runtime data available as early as possible
+    // OpenDTU-OnBattery-specific initializations go between here...
     SolarCharger.init(scheduler);
     PowerMeter.init(scheduler);
     PowerLimiter.init(scheduler);
     GridCharger.init(scheduler);
     Battery.init(scheduler);
+    // ... and here (before RuntimeData)
+
+    // Must be done after all other components have been initialized
+    RuntimeData.init(scheduler);
+    RuntimeData.read();
 
     ESP_LOGI(TAG, "Startup complete");
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,7 @@
 #include <LittleFS.h>
 #include <TaskScheduler.h>
 #include <esp_heap_caps.h>
+#include "RuntimeData.h"
 
 #undef TAG
 static const char* TAG = "main";
@@ -146,6 +147,8 @@ void setup()
     RestartHelper.init(scheduler);
 
     // OpenDTU-OnBattery-specific initializations go below
+    RuntimeData.init(scheduler);
+    RuntimeData.read(); // make runtime data available as early as possible
     SolarCharger.init(scheduler);
     PowerMeter.init(scheduler);
     PowerLimiter.init(scheduler);

--- a/webapp/src/components/FirmwareInfo.vue
+++ b/webapp/src/components/FirmwareInfo.vue
@@ -84,6 +84,10 @@
                         <td>{{ $n(systemStatus.cfgsavecount, 'decimal') }}</td>
                     </tr>
                     <tr>
+                        <th>{{ $t('firmwareinfo.RuntimeSaveCount') }}</th>
+                        <td>{{ systemStatus.runtime_savecount }}</td>
+                    </tr>
+                    <tr>
                         <th>{{ $t('firmwareinfo.Uptime') }}</th>
                         <td>
                             {{ $t('firmwareinfo.UptimeValue', timeInHours(systemStatus.uptime)) }}

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -282,6 +282,7 @@
         "ResetReason0": "Reset Grund CPU 0",
         "ResetReason1": "Reset Grund CPU 1",
         "ConfigSaveCount": "Anzahl der Konfigurationsspeicherungen",
+        "RuntimeSaveCount": "Laufzeitdatenspeicherungen Anzahl / Zeit",
         "Uptime": "Betriebszeit",
         "UptimeValue": "0 Tage {time} | 1 Tag {time} | {count} Tage {time}"
     },

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -1147,6 +1147,7 @@
         "Value": "Wert",
         "Unit": "@:base.Unit",
         "SoC": "Ladezustand (SoC)",
+        "fullyChargedDays": "Tage seit Volladung",
         "stateOfHealth": "Batteriezustand (SoH)",
         "voltage": "Spannung",
         "current": "Strom",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -282,6 +282,7 @@
         "ResetReason0": "Reset Reason CPU 0",
         "ResetReason1": "Reset Reason CPU 1",
         "ConfigSaveCount": "Config save count",
+        "RuntimeSaveCount": "Runtime data save count / time",
         "Uptime": "Uptime",
         "UptimeValue": "0 days {time} | 1 day {time} | {count} days {time}"
     },

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -1151,6 +1151,7 @@
         "Value": "Value",
         "Unit": "@:base.Unit",
         "SoC": "State of Charge",
+        "fullyChargedDays": "Days since fully charged",
         "stateOfHealth": "State of Health",
         "voltage": "Voltage",
         "current": "Current",

--- a/webapp/src/types/SystemStatus.ts
+++ b/webapp/src/types/SystemStatus.ts
@@ -31,6 +31,7 @@ export interface SystemStatus {
     resetreason_0: string;
     resetreason_1: string;
     cfgsavecount: number;
+    runtime_savecount: string;
     uptime: number;
     update_text: string;
     update_url: string;


### PR DESCRIPTION
This pull request adds a new feature to the battery providers. Detects when the battery is fully charged and stores the time in the runtime data.

- General detection for all battery provider that deliver SoC information.
- Special version for the provider 'Victron Smart Shunt' (fully charged time already availabe)
- Prepared to add special versions to other battery providers if required by virtual overload
- Display the value in the live view, but only if the information is available  
- The value is automatically stored in the runtime data JSON-File
- Getter function Battery.getStats()->getFullyChargedTime()

**Worth to notify**

- This PR is based on PR #2262 
- The 'Battery Fully Charged Time' is required for the 'Recharge Helper' which is part of the upcoming improved 'Battery Guard' 
- There is currently no solution for battery providers who do not provide SoC information. A possible solution would be to use battery voltage or battery charger state.

**Additional note**
I've only recently started working with mutex/locks, so the following information should be treated with caution.
I believe the existing member functions Controller::getStats() and Controller::getDischargeCurrentLimit() are not threat safe, because they allow access to shared data outside the scope protected by the lock.

**Testing**
To test the PR on your system, follow these steps:

- Update your system with the new firmware.
- On systems with a 'Victron Smart Shunt' you should see imediatly see the information in the WebUI. 
- On the other provider we must wait until we reach 100% SoC

<img width="300" height="170" alt="grafik" src="https://github.com/user-attachments/assets/6750c82d-ef21-4bc1-a869-1b33717733f6" />
