### PR TITLE
fix: full solar passthrough configuration fault

### DIFF
--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -273,7 +273,8 @@ void PowerLimiterClass::loop()
 
     auto getFullSolarPassthrough = [this,&config]() -> bool {
         // we only do full solar PT if general solar PT is enabled
-        if (!isSolarPassThroughEnabled()) { return false; }
+        // and we are above the 'battery start threshold'
+        if (!isSolarPassThroughEnabled() || !isStartThresholdReached()) { return false; }
 
         if (testThreshold(config.PowerLimiter.FullSolarPassThroughSoc,
                         config.PowerLimiter.FullSolarPassThroughStartVoltage,


### PR DESCRIPTION
does not allow to activate 'full solar passthrough' if battery is below the 'battery start threshold'

Fix #2288